### PR TITLE
Fix: Allow refinery29/php-cs-fixer to pin fabpot/php-cs-fixer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
 
 script:
   - if [[ "$WITH_COVERAGE" == "true" && "$IS_MERGE_TO_MASTER" == "true" ]]; then vendor/bin/phpunit --configuration=phpunit.xml --coverage-clover=build/logs/clover.xml; else vendor/bin/phpunit --configuration=phpunit.xml; fi
-  - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run; fi
+  - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run; fi
 
 after_success:
   - if [[ "$WITH_COVERAGE" == "true" && "$IS_MERGE_TO_MASTER" == "true" ]]; then vendor/bin/test-reporter --coverage-report=build/logs/clover.xml; fi

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ coverage: composer
 	vendor/bin/phpunit --configuration phpunit.xml --coverage-text --columns max
 
 cs: composer
-	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
+	vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff
 
 
 test: composer

--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,16 @@
             "email": "andreas.moller@refinery29.com"
         }
     ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": ">=5.5"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "0.2.0",
-        "fabpot/php-cs-fixer": "2.0.*-dev",
         "fzaninotto/faker": "^1.5",
         "phpunit/phpunit": "^4.8.3",
-        "refinery29/php-cs-fixer-config": "0.2.8"
+        "refinery29/php-cs-fixer-config": "0.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1aef18a143d73e568e209a3b14798fb1",
-    "content-hash": "3f5b1201e8ca1c42a27d3205d765f80d",
+    "hash": "97028c6e2b574f4a93f0de95638ad21f",
+    "content-hash": "b3d5479a21de06c6cd8f28eac4f2e26d",
     "packages": [],
     "packages-dev": [
         {
@@ -126,24 +126,24 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "e66847bbd397026233bde4500c76c7c997ffa5e7"
+                "reference": "518194b0e92dc75e791490b36b51cce39fe80bcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/e66847bbd397026233bde4500c76c7c997ffa5e7",
-                "reference": "e66847bbd397026233bde4500c76c7c997ffa5e7",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/518194b0e92dc75e791490b36b51cce39fe80bcf",
+                "reference": "518194b0e92dc75e791490b36b51cce39fe80bcf",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.6",
-                "sebastian/diff": "~1.1",
-                "symfony/console": "~2.3|~3.0",
-                "symfony/event-dispatcher": "~2.1|~3.0",
-                "symfony/filesystem": "~2.1|~3.0",
-                "symfony/finder": "~2.1|~3.0",
-                "symfony/process": "~2.3|~3.0",
-                "symfony/stopwatch": "~2.5|~3.0"
+                "php": "^5.3.6 || ^7.0",
+                "sebastian/diff": "^1.1",
+                "symfony/console": "^2.3 || ^3.0",
+                "symfony/event-dispatcher": "^2.1 || ^3.0",
+                "symfony/filesystem": "^2.1 || ^3.0",
+                "symfony/finder": "^2.1 || ^3.0",
+                "symfony/process": "^2.3 || ^3.0",
+                "symfony/stopwatch": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "satooshi/php-coveralls": "^1.0"
@@ -159,7 +159,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\CS\\": "src/"
+                    "PhpCsFixer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -177,7 +177,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-01-03 22:51:14"
+            "time": "2016-02-01 02:32:56"
         },
         {
             "name": "fzaninotto/faker",
@@ -843,20 +843,20 @@
         },
         {
             "name": "refinery29/php-cs-fixer-config",
-            "version": "0.2.8",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/refinery29/php-cs-fixer-config.git",
-                "reference": "5bdce0fcbe2771a6f79e18a12650e5033658d660"
+                "reference": "8c614d37a6e71e09762eec95b6a6c2eb0416c8e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/5bdce0fcbe2771a6f79e18a12650e5033658d660",
-                "reference": "5bdce0fcbe2771a6f79e18a12650e5033658d660",
+                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/8c614d37a6e71e09762eec95b6a6c2eb0416c8e4",
+                "reference": "8c614d37a6e71e09762eec95b6a6c2eb0416c8e4",
                 "shasum": ""
             },
             "require": {
-                "fabpot/php-cs-fixer": "2.0.x-dev",
+                "fabpot/php-cs-fixer": "dev-master#518194b",
                 "php": ">=5.5"
             },
             "require-dev": {
@@ -880,7 +880,7 @@
                 }
             ],
             "description": "Provides a configuration for fabpot/php-cs-fixer, used within Refinery29.",
-            "time": "2016-01-06 10:12:20"
+            "time": "2016-02-01 10:51:34"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -1733,11 +1733,9 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
-    "stability-flags": {
-        "fabpot/php-cs-fixer": 20
-    },
-    "prefer-stable": false,
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=5.5"

--- a/src/Component/Image/Image.php
+++ b/src/Component/Image/Image.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Image;
 
 final class Image implements ImageInterface

--- a/src/Component/Image/ImageInterface.php
+++ b/src/Component/Image/ImageInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Image;
 
 /**

--- a/src/Component/News/News.php
+++ b/src/Component/News/News.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\News;
 
 use DateTime;

--- a/src/Component/News/NewsInterface.php
+++ b/src/Component/News/NewsInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\News;
 
 use DateTime;

--- a/src/Component/News/Publication.php
+++ b/src/Component/News/Publication.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\News;
 
 final class Publication implements PublicationInterface

--- a/src/Component/News/PublicationInterface.php
+++ b/src/Component/News/PublicationInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\News;
 
 /**

--- a/src/Component/Sitemap.php
+++ b/src/Component/Sitemap.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component;
 
 use DateTime;

--- a/src/Component/SitemapIndex.php
+++ b/src/Component/SitemapIndex.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component;
 
 final class SitemapIndex implements SitemapIndexInterface

--- a/src/Component/SitemapIndexInterface.php
+++ b/src/Component/SitemapIndexInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component;
 
 /**

--- a/src/Component/SitemapInterface.php
+++ b/src/Component/SitemapInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component;
 
 use DateTime;

--- a/src/Component/Url.php
+++ b/src/Component/Url.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component;
 
 use BadMethodCallException;

--- a/src/Component/UrlInterface.php
+++ b/src/Component/UrlInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component;
 
 use DateTime;

--- a/src/Component/UrlSet.php
+++ b/src/Component/UrlSet.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component;
 
 final class UrlSet implements UrlSetInterface

--- a/src/Component/UrlSetInterface.php
+++ b/src/Component/UrlSetInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component;
 
 /**

--- a/src/Component/Video/GalleryLocation.php
+++ b/src/Component/Video/GalleryLocation.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 final class GalleryLocation implements GalleryLocationInterface

--- a/src/Component/Video/GalleryLocationInterface.php
+++ b/src/Component/Video/GalleryLocationInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 /**

--- a/src/Component/Video/Platform.php
+++ b/src/Component/Video/Platform.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 use BadMethodCallException;

--- a/src/Component/Video/PlatformInterface.php
+++ b/src/Component/Video/PlatformInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 /**

--- a/src/Component/Video/PlayerLocation.php
+++ b/src/Component/Video/PlayerLocation.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 use InvalidArgumentException;

--- a/src/Component/Video/PlayerLocationInterface.php
+++ b/src/Component/Video/PlayerLocationInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 /**

--- a/src/Component/Video/Price.php
+++ b/src/Component/Video/Price.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 use InvalidArgumentException;

--- a/src/Component/Video/PriceInterface.php
+++ b/src/Component/Video/PriceInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 /**

--- a/src/Component/Video/Restriction.php
+++ b/src/Component/Video/Restriction.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 final class Restriction implements RestrictionInterface

--- a/src/Component/Video/RestrictionInterface.php
+++ b/src/Component/Video/RestrictionInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 /**

--- a/src/Component/Video/Tag.php
+++ b/src/Component/Video/Tag.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 final class Tag implements TagInterface

--- a/src/Component/Video/TagInterface.php
+++ b/src/Component/Video/TagInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 interface TagInterface

--- a/src/Component/Video/Uploader.php
+++ b/src/Component/Video/Uploader.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 final class Uploader implements UploaderInterface

--- a/src/Component/Video/UploaderInterface.php
+++ b/src/Component/Video/UploaderInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 /**

--- a/src/Component/Video/Video.php
+++ b/src/Component/Video/Video.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 use BadMethodCallException;

--- a/src/Component/Video/VideoInterface.php
+++ b/src/Component/Video/VideoInterface.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Component\Video;
 
 use DateTime;

--- a/src/Writer/Image/ImageWriter.php
+++ b/src/Writer/Image/ImageWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer\Image;
 
 use Refinery29\Sitemap\Component\Image\ImageInterface;

--- a/src/Writer/News/NewsWriter.php
+++ b/src/Writer/News/NewsWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer\News;
 
 use DateTime;

--- a/src/Writer/News/PublicationWriter.php
+++ b/src/Writer/News/PublicationWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer\News;
 
 use Refinery29\Sitemap\Component\News\PublicationInterface;

--- a/src/Writer/SitemapIndexWriter.php
+++ b/src/Writer/SitemapIndexWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer;
 
 use Refinery29\Sitemap\Component\SitemapIndexInterface;

--- a/src/Writer/SitemapWriter.php
+++ b/src/Writer/SitemapWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer;
 
 use DateTime;

--- a/src/Writer/UrlSetWriter.php
+++ b/src/Writer/UrlSetWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer;
 
 use Refinery29\Sitemap\Component\Image\Image;

--- a/src/Writer/UrlWriter.php
+++ b/src/Writer/UrlWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer;
 
 use DateTime;

--- a/src/Writer/Video/GalleryLocationWriter.php
+++ b/src/Writer/Video/GalleryLocationWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer\Video;
 
 use Refinery29\Sitemap\Component\Video\GalleryLocationInterface;

--- a/src/Writer/Video/PlatformWriter.php
+++ b/src/Writer/Video/PlatformWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer\Video;
 
 use Refinery29\Sitemap\Component\Video\PlatformInterface;

--- a/src/Writer/Video/PlayerLocationWriter.php
+++ b/src/Writer/Video/PlayerLocationWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer\Video;
 
 use Refinery29\Sitemap\Component\Video\PlayerLocationInterface;

--- a/src/Writer/Video/PriceWriter.php
+++ b/src/Writer/Video/PriceWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer\Video;
 
 use Refinery29\Sitemap\Component\Video\PriceInterface;

--- a/src/Writer/Video/RestrictionWriter.php
+++ b/src/Writer/Video/RestrictionWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer\Video;
 
 use Refinery29\Sitemap\Component\Video\RestrictionInterface;

--- a/src/Writer/Video/TagWriter.php
+++ b/src/Writer/Video/TagWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer\Video;
 
 use Refinery29\Sitemap\Component\Video\TagInterface;

--- a/src/Writer/Video/UploaderWriter.php
+++ b/src/Writer/Video/UploaderWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer\Video;
 
 use Refinery29\Sitemap\Component\Video\UploaderInterface;

--- a/src/Writer/Video/VideoWriter.php
+++ b/src/Writer/Video/VideoWriter.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Writer\Video;
 
 use DateTime;

--- a/test/Component/Image/ImageTest.php
+++ b/test/Component/Image/ImageTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component\Image;
 
 use Refinery29\Sitemap\Component\Image\Image;

--- a/test/Component/News/NewsTest.php
+++ b/test/Component/News/NewsTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component\News;
 
 use InvalidArgumentException;
@@ -201,7 +200,7 @@ class NewsTest extends \PHPUnit_Framework_TestCase
 
         $faker = $this->getFaker();
 
-        for ($i = 0; $i < count($allowedValues); $i++) {
+        for ($i = 0; $i < count($allowedValues); ++$i) {
             yield [
                 $faker->randomElements($allowedValues, $i),
             ];

--- a/test/Component/News/PublicationTest.php
+++ b/test/Component/News/PublicationTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component\News;
 
 use Refinery29\Sitemap\Component\News\Publication;

--- a/test/Component/SitemapIndexTest.php
+++ b/test/Component/SitemapIndexTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component;
 
 use Refinery29\Sitemap\Component\SitemapIndex;

--- a/test/Component/SitemapTest.php
+++ b/test/Component/SitemapTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component;
 
 use Refinery29\Sitemap\Component\Sitemap;

--- a/test/Component/UrlSetTest.php
+++ b/test/Component/UrlSetTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component;
 
 use Refinery29\Sitemap\Component\UrlInterface;

--- a/test/Component/UrlTest.php
+++ b/test/Component/UrlTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component;
 
 use BadMethodCallException;

--- a/test/Component/Video/GalleryLocationTest.php
+++ b/test/Component/Video/GalleryLocationTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\GalleryLocation;

--- a/test/Component/Video/PlatformTest.php
+++ b/test/Component/Video/PlatformTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component\Video;
 
 use BadMethodCallException;

--- a/test/Component/Video/PlayerLocationTest.php
+++ b/test/Component/Video/PlayerLocationTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component\Video;
 
 use InvalidArgumentException;

--- a/test/Component/Video/PriceTest.php
+++ b/test/Component/Video/PriceTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component\Video;
 
 use InvalidArgumentException;

--- a/test/Component/Video/RestrictionTest.php
+++ b/test/Component/Video/RestrictionTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component\Video;
 
 use InvalidArgumentException;

--- a/test/Component/Video/TagTest.php
+++ b/test/Component/Video/TagTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\Tag;

--- a/test/Component/Video/UploaderTest.php
+++ b/test/Component/Video/UploaderTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\Uploader;

--- a/test/Component/Video/VideoTest.php
+++ b/test/Component/Video/VideoTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Component\Video;
 
 use BadMethodCallException;
@@ -479,7 +478,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             $faker->url
         );
 
-        for ($i = 0; $i < Video::TAG_MAX_COUNT; $i++) {
+        for ($i = 0; $i < Video::TAG_MAX_COUNT; ++$i) {
             $video->addTag($this->getTagMock());
         }
 

--- a/test/Util/FakerTrait.php
+++ b/test/Util/FakerTrait.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Util;
 
 use Faker\Factory;

--- a/test/Writer/AbstractTestCase.php
+++ b/test/Writer/AbstractTestCase.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer;
 
 use Refinery29\Sitemap\Test\Util\FakerTrait;

--- a/test/Writer/Image/ImageWriterTest.php
+++ b/test/Writer/Image/ImageWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer;
 
 use Refinery29\Sitemap\Component\Image\ImageInterface;

--- a/test/Writer/News/NewsWriterTest.php
+++ b/test/Writer/News/NewsWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer\News;
 
 use DateTime;

--- a/test/Writer/News/PublicationWriterTest.php
+++ b/test/Writer/News/PublicationWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer\News;
 
 use Refinery29\Sitemap\Component\News\PublicationInterface;

--- a/test/Writer/SitemapIndexWriterTest.php
+++ b/test/Writer/SitemapIndexWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer;
 
 use Refinery29\Sitemap\Component\SitemapIndexInterface;

--- a/test/Writer/SitemapWriterTest.php
+++ b/test/Writer/SitemapWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer;
 
 use DateTime;

--- a/test/Writer/UrlSetWriterTest.php
+++ b/test/Writer/UrlSetWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer;
 
 use Refinery29\Sitemap\Component\Image\Image;

--- a/test/Writer/UrlWriterTest.php
+++ b/test/Writer/UrlWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer;
 
 use DateTime;

--- a/test/Writer/Video/GalleryLocationWriterTest.php
+++ b/test/Writer/Video/GalleryLocationWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer\Video;
 
 use Refinery29\Sitemap\Component\Video\GalleryLocationInterface;

--- a/test/Writer/Video/PlatformWriterTest.php
+++ b/test/Writer/Video/PlatformWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer\Video;
 
 use Refinery29\Sitemap\Component\Video\Platform;

--- a/test/Writer/Video/PlayerLocationWriterTest.php
+++ b/test/Writer/Video/PlayerLocationWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer\Video;
 
 use Refinery29\Sitemap\Component\Video\PlayerLocation;

--- a/test/Writer/Video/PriceWriterTest.php
+++ b/test/Writer/Video/PriceWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer\Video;
 
 use Refinery29\Sitemap\Component\Video\Price;

--- a/test/Writer/Video/RestrictionWriterTest.php
+++ b/test/Writer/Video/RestrictionWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer\Video;
 
 use Refinery29\Sitemap\Component\Video\Restriction;

--- a/test/Writer/Video/TagWriterTest.php
+++ b/test/Writer/Video/TagWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer\Video;
 
 use Refinery29\Sitemap\Component\Video\TagInterface;

--- a/test/Writer/Video/UploaderWriterTest.php
+++ b/test/Writer/Video/UploaderWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer\Video;
 
 use Refinery29\Sitemap\Component\Video\UploaderInterface;

--- a/test/Writer/Video/VideoWriterTest.php
+++ b/test/Writer/Video/VideoWriterTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Sitemap\Test\Writer\Video;
 
 use DateTime;


### PR DESCRIPTION
This PR

* [x] allows `refinery29/php-cs-fixer-config` to dictate which version of `fabpot/php-cs-fixer` is used
* [x] runs `make cs`

:information_desk_person: For reference, see https://github.com/refinery29/php-cs-fixer-config#installation.