### PR TITLE
Fix: Move constants to interfaces

### DIFF
--- a/src/Component/Image/Image.php
+++ b/src/Component/Image/Image.php
@@ -11,12 +11,6 @@ namespace Refinery29\Sitemap\Component\Image;
 final class Image implements ImageInterface
 {
     /**
-     * Constants for XML namespace attribute and URI.
-     */
-    const XML_NAMESPACE_ATTRIBUTE = 'xmlns:image';
-    const XML_NAMESPACE_URI = 'http://www.google.com/schemas/sitemap-image/1.1';
-
-    /**
      * @var string
      */
     private $location;

--- a/src/Component/Image/ImageInterface.php
+++ b/src/Component/Image/ImageInterface.php
@@ -14,6 +14,12 @@ namespace Refinery29\Sitemap\Component\Image;
 interface ImageInterface
 {
     /**
+     * Constants for XML namespace attribute and URI.
+     */
+    const XML_NAMESPACE_ATTRIBUTE = 'xmlns:image';
+    const XML_NAMESPACE_URI = 'http://www.google.com/schemas/sitemap-image/1.1';
+
+    /**
      * @return string
      */
     public function getLocation();

--- a/src/Component/News/News.php
+++ b/src/Component/News/News.php
@@ -14,38 +14,6 @@ use InvalidArgumentException;
 final class News implements NewsInterface
 {
     /**
-     * Constants for XML namespace attribute and URI.
-     */
-    const XML_NAMESPACE_ATTRIBUTE = 'xmlns:news';
-    const XML_NAMESPACE_URI = 'http://www.google.com/schemas/sitemap-news/0.9';
-
-    /**
-     * Constants for access types.
-     *
-     * @link https://support.google.com/news/publisher/answer/93992
-     */
-    const ACCESS_SUBSCRIPTION = 'Subscription';
-    const ACCESS_REGISTRATION = 'Registration';
-
-    /**
-     * Constants for genres.
-     *
-     * @link https://support.google.com/news/publisher/answer/93992
-     */
-    const GENRE_BLOG = 'Blog';
-    const GENRE_OP_ED = 'OpEd';
-    const GENRE_OPINION = 'Opinion';
-    const GENRE_SATIRE = 'Satire';
-    const GENRE_USER_GENERATED = 'UserGenerated';
-
-    /**
-     * Constant for maximum number of allowed stock tickers.
-     *
-     * @link https://support.google.com/news/publisher/answer/93992
-     */
-    const STOCK_TICKERS_MAX_COUNT = 5;
-
-    /**
      * @var PublicationInterface
      */
     private $publication;
@@ -135,8 +103,8 @@ final class News implements NewsInterface
         }
 
         $allowedValues = [
-            self::ACCESS_REGISTRATION,
-            self::ACCESS_SUBSCRIPTION,
+            NewsInterface::ACCESS_REGISTRATION,
+            NewsInterface::ACCESS_SUBSCRIPTION,
         ];
 
         if (!in_array($access, $allowedValues)) {
@@ -165,11 +133,11 @@ final class News implements NewsInterface
         }
 
         $allowedValues = [
-            self::GENRE_BLOG,
-            self::GENRE_OP_ED,
-            self::GENRE_OPINION,
-            self::GENRE_SATIRE,
-            self::GENRE_USER_GENERATED,
+            NewsInterface::GENRE_BLOG,
+            NewsInterface::GENRE_OP_ED,
+            NewsInterface::GENRE_OPINION,
+            NewsInterface::GENRE_SATIRE,
+            NewsInterface::GENRE_USER_GENERATED,
         ];
 
         $invalidValues = array_filter($genres, function ($genre) use ($allowedValues) {
@@ -206,11 +174,11 @@ final class News implements NewsInterface
             return;
         }
 
-        if (count($stockTickers) > self::STOCK_TICKERS_MAX_COUNT) {
+        if (count($stockTickers) > NewsInterface::STOCK_TICKERS_MAX_COUNT) {
             throw new InvalidArgumentException(sprintf(
                 'Optional parameter "%s" needs to be specified as an array with at most "%s" elements',
                 'stockTickers',
-                self::STOCK_TICKERS_MAX_COUNT
+                NewsInterface::STOCK_TICKERS_MAX_COUNT
             ));
         }
 

--- a/src/Component/News/NewsInterface.php
+++ b/src/Component/News/NewsInterface.php
@@ -16,6 +16,38 @@ use DateTime;
 interface NewsInterface
 {
     /**
+     * Constants for XML namespace attribute and URI.
+     */
+    const XML_NAMESPACE_ATTRIBUTE = 'xmlns:news';
+    const XML_NAMESPACE_URI = 'http://www.google.com/schemas/sitemap-news/0.9';
+
+    /**
+     * Constants for access types.
+     *
+     * @link https://support.google.com/news/publisher/answer/93992
+     */
+    const ACCESS_SUBSCRIPTION = 'Subscription';
+    const ACCESS_REGISTRATION = 'Registration';
+
+    /**
+     * Constants for genres.
+     *
+     * @link https://support.google.com/news/publisher/answer/93992
+     */
+    const GENRE_BLOG = 'Blog';
+    const GENRE_OP_ED = 'OpEd';
+    const GENRE_OPINION = 'Opinion';
+    const GENRE_SATIRE = 'Satire';
+    const GENRE_USER_GENERATED = 'UserGenerated';
+
+    /**
+     * Constant for maximum number of allowed stock tickers.
+     *
+     * @link https://support.google.com/news/publisher/answer/93992
+     */
+    const STOCK_TICKERS_MAX_COUNT = 5;
+
+    /**
      * @return PublicationInterface
      */
     public function getPublication();

--- a/src/Component/Url.php
+++ b/src/Component/Url.php
@@ -16,21 +16,6 @@ use Refinery29\Sitemap\Component\Video\VideoInterface;
 
 final class Url implements UrlInterface
 {
-    const CHANGE_FREQUENCY_ALWAYS = 'always';
-    const CHANGE_FREQUENCY_HOURLY = 'hourly';
-    const CHANGE_FREQUENCY_DAILY = 'daily';
-    const CHANGE_FREQUENCY_WEEKLY = 'weekly';
-    const CHANGE_FREQUENCY_MONTHLY = 'monthly';
-    const CHANGE_FREQUENCY_YEARLY = 'yearly';
-    const CHANGE_FREQUENCY_NEVER = 'never';
-
-    /**
-     * Constant for maximum number of images.
-     *
-     * @link https://support.google.com/webmasters/answer/178636?hl=en
-     */
-    const IMAGE_MAX_COUNT = 1000;
-
     /**
      * @var string
      */
@@ -109,10 +94,10 @@ final class Url implements UrlInterface
      */
     public function addImage(ImageInterface $image)
     {
-        if (count($this->images) === self::IMAGE_MAX_COUNT) {
+        if (count($this->images) === UrlInterface::IMAGE_MAX_COUNT) {
             throw new BadMethodCallException(sprintf(
                 'Can not add more than %s images',
-                self::IMAGE_MAX_COUNT
+                UrlInterface::IMAGE_MAX_COUNT
             ));
         }
 

--- a/src/Component/UrlInterface.php
+++ b/src/Component/UrlInterface.php
@@ -16,6 +16,24 @@ use DateTime;
 interface UrlInterface
 {
     /**
+     * Constants for change frequencies.
+     */
+    const CHANGE_FREQUENCY_ALWAYS = 'always';
+    const CHANGE_FREQUENCY_HOURLY = 'hourly';
+    const CHANGE_FREQUENCY_DAILY = 'daily';
+    const CHANGE_FREQUENCY_WEEKLY = 'weekly';
+    const CHANGE_FREQUENCY_MONTHLY = 'monthly';
+    const CHANGE_FREQUENCY_YEARLY = 'yearly';
+    const CHANGE_FREQUENCY_NEVER = 'never';
+
+    /**
+     * Constant for maximum number of images.
+     *
+     * @link https://support.google.com/webmasters/answer/178636?hl=en
+     */
+    const IMAGE_MAX_COUNT = 1000;
+
+    /**
      * @return string
      */
     public function getLocation();

--- a/src/Component/UrlSet.php
+++ b/src/Component/UrlSet.php
@@ -11,12 +11,6 @@ namespace Refinery29\Sitemap\Component;
 final class UrlSet implements UrlSetInterface
 {
     /**
-     * Constant for XML namespace attribute and URI.
-     */
-    const XML_NAMESPACE_ATTRIBUTE = 'xmlns';
-    const XML_NAMESPACE_URI = 'http://www.sitemaps.org/schemas/sitemap/0.9';
-
-    /**
      * @var UrlInterface[]
      */
     private $urls = [];

--- a/src/Component/UrlSetInterface.php
+++ b/src/Component/UrlSetInterface.php
@@ -14,6 +14,12 @@ namespace Refinery29\Sitemap\Component;
 interface UrlSetInterface
 {
     /**
+     * Constant for XML namespace attribute and URI.
+     */
+    const XML_NAMESPACE_ATTRIBUTE = 'xmlns';
+    const XML_NAMESPACE_URI = 'http://www.sitemaps.org/schemas/sitemap/0.9';
+
+    /**
      * @param UrlInterface $url
      */
     public function addUrl(UrlInterface $url);

--- a/src/Component/Video/Platform.php
+++ b/src/Component/Video/Platform.php
@@ -14,23 +14,6 @@ use InvalidArgumentException;
 final class Platform implements PlatformInterface
 {
     /**
-     * Constants for types.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const TYPE_MOBILE = 'mobile';
-    const TYPE_TV = 'tv';
-    const TYPE_WEB = 'web';
-
-    /**
-     * Constants for resolutions.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const RELATIONSHIP_ALLOW = 'allow';
-    const RELATIONSHIP_DENY = 'deny';
-
-    /**
      * @var string
      */
     private $relationship;
@@ -54,8 +37,8 @@ final class Platform implements PlatformInterface
     private function setRelationship($relationship)
     {
         $allowedValues = [
-            self::RELATIONSHIP_ALLOW,
-            self::RELATIONSHIP_DENY,
+            PlatformInterface::RELATIONSHIP_ALLOW,
+            PlatformInterface::RELATIONSHIP_DENY,
         ];
 
         if (!is_string($relationship) || !in_array($relationship, $allowedValues)) {
@@ -80,9 +63,9 @@ final class Platform implements PlatformInterface
     public function addType($type)
     {
         $allowedValues = [
-            self::TYPE_MOBILE,
-            self::TYPE_TV,
-            self::TYPE_WEB,
+            PlatformInterface::TYPE_MOBILE,
+            PlatformInterface::TYPE_TV,
+            PlatformInterface::TYPE_WEB,
         ];
 
         if (!is_string($type) || !in_array($type, $allowedValues)) {

--- a/src/Component/Video/PlatformInterface.php
+++ b/src/Component/Video/PlatformInterface.php
@@ -14,6 +14,23 @@ namespace Refinery29\Sitemap\Component\Video;
 interface PlatformInterface
 {
     /**
+     * Constants for types.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const TYPE_MOBILE = 'mobile';
+    const TYPE_TV = 'tv';
+    const TYPE_WEB = 'web';
+
+    /**
+     * Constants for resolutions.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const RELATIONSHIP_ALLOW = 'allow';
+    const RELATIONSHIP_DENY = 'deny';
+
+    /**
      * @return string
      */
     public function getRelationship();

--- a/src/Component/Video/PlayerLocation.php
+++ b/src/Component/Video/PlayerLocation.php
@@ -13,14 +13,6 @@ use InvalidArgumentException;
 final class PlayerLocation implements PlayerLocationInterface
 {
     /**
-     * Constants for allow embedding values.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const ALLOW_EMBED_YES = 'yes';
-    const ALLOW_EMBED_NO = 'no';
-
-    /**
      * @var string
      */
     private $location;
@@ -64,8 +56,8 @@ final class PlayerLocation implements PlayerLocationInterface
         }
 
         $allowedValues = [
-            self::ALLOW_EMBED_NO,
-            self::ALLOW_EMBED_YES,
+            PlayerLocationInterface::ALLOW_EMBED_NO,
+            PlayerLocationInterface::ALLOW_EMBED_YES,
         ];
 
         if (!in_array($allowEmbed, $allowedValues)) {

--- a/src/Component/Video/PlayerLocationInterface.php
+++ b/src/Component/Video/PlayerLocationInterface.php
@@ -14,6 +14,14 @@ namespace Refinery29\Sitemap\Component\Video;
 interface PlayerLocationInterface
 {
     /**
+     * Constants for allow embedding values.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const ALLOW_EMBED_YES = 'yes';
+    const ALLOW_EMBED_NO = 'no';
+
+    /**
      * @return string
      */
     public function getLocation();

--- a/src/Component/Video/Price.php
+++ b/src/Component/Video/Price.php
@@ -13,27 +13,6 @@ use InvalidArgumentException;
 final class Price implements PriceInterface
 {
     /**
-     * Constant for minimum value.
-     */
-    const VALUE_MIN = 0.01;
-
-    /**
-     * Constants for types.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const TYPE_OWN = 'own';
-    const TYPE_RENT = 'rent';
-
-    /**
-     * Constants for resolutions.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const RESOLUTION_HD = 'HD';
-    const RESOLUTION_SD = 'SD';
-
-    /**
      * @var float
      */
     private $value;
@@ -74,11 +53,11 @@ final class Price implements PriceInterface
      */
     private function setValue($value)
     {
-        if (!is_numeric($value) || $value < self::VALUE_MIN) {
+        if (!is_numeric($value) || $value < PriceInterface::VALUE_MIN) {
             throw new InvalidArgumentException(sprintf(
                 'Parameter "%s" needs to be specified as a number greater than "%s"',
                 $value,
-                self::VALUE_MIN
+                PriceInterface::VALUE_MIN
             ));
         }
 
@@ -105,8 +84,8 @@ final class Price implements PriceInterface
         }
 
         $allowedValues = [
-            self::TYPE_OWN,
-            self::TYPE_RENT,
+            PriceInterface::TYPE_OWN,
+            PriceInterface::TYPE_RENT,
         ];
 
         if (!is_string($type) || !in_array($type, $allowedValues)) {
@@ -135,8 +114,8 @@ final class Price implements PriceInterface
         }
 
         $allowedValues = [
-            self::RESOLUTION_HD,
-            self::RESOLUTION_SD,
+            PriceInterface::RESOLUTION_HD,
+            PriceInterface::RESOLUTION_SD,
         ];
 
         if (!is_string($resolution) || !in_array($resolution, $allowedValues)) {

--- a/src/Component/Video/PriceInterface.php
+++ b/src/Component/Video/PriceInterface.php
@@ -14,6 +14,27 @@ namespace Refinery29\Sitemap\Component\Video;
 interface PriceInterface
 {
     /**
+     * Constant for minimum value.
+     */
+    const VALUE_MIN = 0.01;
+
+    /**
+     * Constants for types.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const TYPE_OWN = 'own';
+    const TYPE_RENT = 'rent';
+
+    /**
+     * Constants for resolutions.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const RESOLUTION_HD = 'HD';
+    const RESOLUTION_SD = 'SD';
+
+    /**
      * @return float
      */
     public function getValue();

--- a/src/Component/Video/Restriction.php
+++ b/src/Component/Video/Restriction.php
@@ -11,14 +11,6 @@ namespace Refinery29\Sitemap\Component\Video;
 final class Restriction implements RestrictionInterface
 {
     /**
-     * Constants for relationships.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const RELATIONSHIP_ALLOW = 'allow';
-    const RELATIONSHIP_DENY = 'deny';
-
-    /**
      * @var string
      */
     private $relationship;
@@ -42,8 +34,8 @@ final class Restriction implements RestrictionInterface
     private function setRelationship($relationship)
     {
         $allowedValues = [
-            self::RELATIONSHIP_ALLOW,
-            self::RELATIONSHIP_DENY,
+            RestrictionInterface::RELATIONSHIP_ALLOW,
+            RestrictionInterface::RELATIONSHIP_DENY,
         ];
 
         if (!is_string($relationship) || !in_array($relationship, $allowedValues)) {

--- a/src/Component/Video/RestrictionInterface.php
+++ b/src/Component/Video/RestrictionInterface.php
@@ -14,6 +14,14 @@ namespace Refinery29\Sitemap\Component\Video;
 interface RestrictionInterface
 {
     /**
+     * Constants for relationships.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const RELATIONSHIP_ALLOW = 'allow';
+    const RELATIONSHIP_DENY = 'deny';
+
+    /**
      * @return string
      */
     public function getRelationship();

--- a/src/Component/Video/Video.php
+++ b/src/Component/Video/Video.php
@@ -15,79 +15,6 @@ use InvalidArgumentException;
 class Video implements VideoInterface
 {
     /**
-     * Constants for XML namespace attribute and URI.
-     */
-    const XML_NAMESPACE_ATTRIBUTE = 'xmlns:video';
-    const XML_NAMESPACE_URI = 'http://www.google.com/schemas/sitemap-video/1.1';
-
-    /**
-     * Constant for maximum title length.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const TITLE_MAX_LENGTH = 100;
-
-    /**
-     * Constant for maximum description length.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const DESCRIPTION_MAX_LENGTH = 2048;
-
-    /**
-     * Constants for duration limits.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const DURATION_LOWER_LIMIT = 0;
-    const DURATION_UPPER_LIMIT = 28800;
-
-    /**
-     * Constants for rating minimum and maximum values.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const RATING_MIN = 0.0;
-    const RATING_MAX = 5.0;
-
-    /**
-     * Constants for subscription requirement.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const REQUIRES_SUBSCRIPTION_NO = 'no';
-    const REQUIRES_SUBSCRIPTION_YES = 'yes';
-
-    /**
-     * Constants for family friendliness.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const FAMILY_FRIENDLY_NO = 'no';
-
-    /**
-     * Constants for category maximum length.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const CATEGORY_MAX_LENGTH = 256;
-
-    /**
-     * Constants for maximum number of allowed tags.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const TAG_MAX_COUNT = 32;
-
-    /**
-     * Constants for live.
-     *
-     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
-     */
-    const LIVE_YES = 'yes';
-    const LIVE_NO = 'no';
-
-    /**
      * @var string
      */
     private $thumbnailLocation;
@@ -276,11 +203,11 @@ class Video implements VideoInterface
      */
     private function setTitle($title)
     {
-        if (!is_string($title) || mb_strlen($title) > self::TITLE_MAX_LENGTH) {
+        if (!is_string($title) || mb_strlen($title) > VideoInterface::TITLE_MAX_LENGTH) {
             throw new InvalidArgumentException(sprintf(
                 'Parameter "%s" needs to be specified as a string not longer than "%s" characters',
                 'title',
-                self::TITLE_MAX_LENGTH
+                VideoInterface::TITLE_MAX_LENGTH
             ));
         }
 
@@ -297,11 +224,11 @@ class Video implements VideoInterface
      */
     private function setDescription($description)
     {
-        if (!is_string($description) || mb_strlen($description) > self::DESCRIPTION_MAX_LENGTH) {
+        if (!is_string($description) || mb_strlen($description) > VideoInterface::DESCRIPTION_MAX_LENGTH) {
             throw new InvalidArgumentException(sprintf(
                 'Optional parameter "%s" needs to be specified as a string not longer than "%s" characters',
                 'description',
-                self::DESCRIPTION_MAX_LENGTH
+                VideoInterface::DESCRIPTION_MAX_LENGTH
             ));
         }
 
@@ -337,12 +264,12 @@ class Video implements VideoInterface
             return;
         }
 
-        if (!is_int($duration) || $duration <= self::DURATION_LOWER_LIMIT || $duration >= self::DURATION_UPPER_LIMIT) {
+        if (!is_int($duration) || $duration <= VideoInterface::DURATION_LOWER_LIMIT || $duration >= VideoInterface::DURATION_UPPER_LIMIT) {
             throw new InvalidArgumentException(sprintf(
                 'Optional parameter "%s" needs to be specified as an integer greater than "%s" and smaller than "%s"',
                 'duration',
-                self::DURATION_LOWER_LIMIT,
-                self::DURATION_UPPER_LIMIT
+                VideoInterface::DURATION_LOWER_LIMIT,
+                VideoInterface::DURATION_UPPER_LIMIT
             ));
         }
 
@@ -381,12 +308,12 @@ class Video implements VideoInterface
             return;
         }
 
-        if (!is_numeric($rating) || $rating < self::RATING_MIN || $rating > self::RATING_MAX) {
+        if (!is_numeric($rating) || $rating < VideoInterface::RATING_MIN || $rating > VideoInterface::RATING_MAX) {
             throw new InvalidArgumentException(sprintf(
                 'Optional parameter "%s" needs to be specified as a number not smaller than "%s" and not greater than "%s"',
                 'rating',
-                self::RATING_MIN,
-                self::RATING_MAX
+                VideoInterface::RATING_MIN,
+                VideoInterface::RATING_MAX
             ));
         }
 
@@ -432,11 +359,11 @@ class Video implements VideoInterface
             return;
         }
 
-        if ($familyFriendly !== self::FAMILY_FRIENDLY_NO) {
+        if ($familyFriendly !== VideoInterface::FAMILY_FRIENDLY_NO) {
             throw new InvalidArgumentException(sprintf(
                 'Optional parameter "%s" needs to be specified as "%s"',
                 'familyFriendly',
-                self::FAMILY_FRIENDLY_NO
+                VideoInterface::FAMILY_FRIENDLY_NO
             ));
         }
 
@@ -453,10 +380,10 @@ class Video implements VideoInterface
      */
     public function addTag(TagInterface $tag)
     {
-        if (count($this->tags) === self::TAG_MAX_COUNT) {
+        if (count($this->tags) === VideoInterface::TAG_MAX_COUNT) {
             throw new BadMethodCallException(sprintf(
                 'Can not add more than %s tags',
-                self::TAG_MAX_COUNT
+                VideoInterface::TAG_MAX_COUNT
             ));
         }
 
@@ -477,11 +404,11 @@ class Video implements VideoInterface
             return;
         }
 
-        if (!is_string($category) || mb_strlen($category) > self::CATEGORY_MAX_LENGTH) {
+        if (!is_string($category) || mb_strlen($category) > VideoInterface::CATEGORY_MAX_LENGTH) {
             throw new InvalidArgumentException(sprintf(
                 'Optional parameter "%s" needs to be specified as a string not longer than "%s" characters',
                 'category',
-                self::CATEGORY_MAX_LENGTH
+                VideoInterface::CATEGORY_MAX_LENGTH
             ));
         }
 
@@ -521,8 +448,8 @@ class Video implements VideoInterface
         }
 
         $allowedValues = [
-            self::REQUIRES_SUBSCRIPTION_NO,
-            self::REQUIRES_SUBSCRIPTION_YES,
+            VideoInterface::REQUIRES_SUBSCRIPTION_NO,
+            VideoInterface::REQUIRES_SUBSCRIPTION_YES,
         ];
 
         if (!is_string($requiresSubscription) || !in_array($requiresSubscription, $allowedValues)) {
@@ -561,8 +488,8 @@ class Video implements VideoInterface
         }
 
         $allowedValues = [
-            self::LIVE_NO,
-            self::LIVE_YES,
+            VideoInterface::LIVE_NO,
+            VideoInterface::LIVE_YES,
         ];
 
         if (!is_string($live) || !in_array($live, $allowedValues)) {

--- a/src/Component/Video/VideoInterface.php
+++ b/src/Component/Video/VideoInterface.php
@@ -16,6 +16,79 @@ use DateTime;
 interface VideoInterface
 {
     /**
+     * Constants for XML namespace attribute and URI.
+     */
+    const XML_NAMESPACE_ATTRIBUTE = 'xmlns:video';
+    const XML_NAMESPACE_URI = 'http://www.google.com/schemas/sitemap-video/1.1';
+
+    /**
+     * Constant for maximum title length.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const TITLE_MAX_LENGTH = 100;
+
+    /**
+     * Constant for maximum description length.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const DESCRIPTION_MAX_LENGTH = 2048;
+
+    /**
+     * Constants for duration limits.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const DURATION_LOWER_LIMIT = 0;
+    const DURATION_UPPER_LIMIT = 28800;
+
+    /**
+     * Constants for rating minimum and maximum values.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const RATING_MIN = 0.0;
+    const RATING_MAX = 5.0;
+
+    /**
+     * Constants for subscription requirement.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const REQUIRES_SUBSCRIPTION_NO = 'no';
+    const REQUIRES_SUBSCRIPTION_YES = 'yes';
+
+    /**
+     * Constants for family friendliness.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const FAMILY_FRIENDLY_NO = 'no';
+
+    /**
+     * Constants for category maximum length.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const CATEGORY_MAX_LENGTH = 256;
+
+    /**
+     * Constants for maximum number of allowed tags.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const TAG_MAX_COUNT = 32;
+
+    /**
+     * Constants for live.
+     *
+     * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+     */
+    const LIVE_YES = 'yes';
+    const LIVE_NO = 'no';
+
+    /**
      * @return string
      */
     public function getThumbnailLocation();

--- a/src/Writer/UrlSetWriter.php
+++ b/src/Writer/UrlSetWriter.php
@@ -8,12 +8,11 @@
  */
 namespace Refinery29\Sitemap\Writer;
 
-use Refinery29\Sitemap\Component\Image\Image;
-use Refinery29\Sitemap\Component\News\News;
+use Refinery29\Sitemap\Component\Image\ImageInterface;
+use Refinery29\Sitemap\Component\News\NewsInterface;
 use Refinery29\Sitemap\Component\UrlInterface;
-use Refinery29\Sitemap\Component\UrlSet;
 use Refinery29\Sitemap\Component\UrlSetInterface;
-use Refinery29\Sitemap\Component\Video\Video;
+use Refinery29\Sitemap\Component\Video\VideoInterface;
 use XMLWriter;
 
 /**
@@ -53,10 +52,10 @@ class UrlSetWriter
      */
     private function writeNamespaceAttributes(XMLWriter $xmlWriter)
     {
-        $xmlWriter->writeAttribute(UrlSet::XML_NAMESPACE_ATTRIBUTE, UrlSet::XML_NAMESPACE_URI);
-        $xmlWriter->writeAttribute(Image::XML_NAMESPACE_ATTRIBUTE, Image::XML_NAMESPACE_URI);
-        $xmlWriter->writeAttribute(News::XML_NAMESPACE_ATTRIBUTE, News::XML_NAMESPACE_URI);
-        $xmlWriter->writeAttribute(Video::XML_NAMESPACE_ATTRIBUTE, Video::XML_NAMESPACE_URI);
+        $xmlWriter->writeAttribute(UrlSetInterface::XML_NAMESPACE_ATTRIBUTE, UrlSetInterface::XML_NAMESPACE_URI);
+        $xmlWriter->writeAttribute(ImageInterface::XML_NAMESPACE_ATTRIBUTE, ImageInterface::XML_NAMESPACE_URI);
+        $xmlWriter->writeAttribute(NewsInterface::XML_NAMESPACE_ATTRIBUTE, NewsInterface::XML_NAMESPACE_URI);
+        $xmlWriter->writeAttribute(VideoInterface::XML_NAMESPACE_ATTRIBUTE, VideoInterface::XML_NAMESPACE_URI);
     }
 
     /**

--- a/test/Component/Image/ImageInterfaceTest.php
+++ b/test/Component/Image/ImageInterfaceTest.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+namespace Refinery29\Sitemap\Test\Component\Image;
+
+use Refinery29\Sitemap\Component\Image\ImageInterface;
+
+class ImageInterfaceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstants()
+    {
+        $this->assertSame('xmlns:image', ImageInterface::XML_NAMESPACE_ATTRIBUTE);
+        $this->assertSame('http://www.google.com/schemas/sitemap-image/1.1', ImageInterface::XML_NAMESPACE_URI);
+    }
+}

--- a/test/Component/Image/ImageTest.php
+++ b/test/Component/Image/ImageTest.php
@@ -16,12 +16,6 @@ class ImageTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 
-    public function testConstants()
-    {
-        $this->assertSame('xmlns:image', Image::XML_NAMESPACE_ATTRIBUTE);
-        $this->assertSame('http://www.google.com/schemas/sitemap-image/1.1', Image::XML_NAMESPACE_URI);
-    }
-
     public function testImplementsInterface()
     {
         $location = $this->getFaker()->url;

--- a/test/Component/News/NewsInterfaceTest.php
+++ b/test/Component/News/NewsInterfaceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+namespace Refinery29\Sitemap\Test\Component\News;
+
+use Refinery29\Sitemap\Component\News\NewsInterface;
+use Refinery29\Test\Util\Faker\GeneratorTrait;
+
+class NewsInterfaceTest extends \PHPUnit_Framework_TestCase
+{
+    use GeneratorTrait;
+
+    public function testConstants()
+    {
+        $this->assertSame('xmlns:news', NewsInterface::XML_NAMESPACE_ATTRIBUTE);
+        $this->assertSame('http://www.google.com/schemas/sitemap-news/0.9', NewsInterface::XML_NAMESPACE_URI);
+
+        $this->assertSame('Registration', NewsInterface::ACCESS_REGISTRATION);
+        $this->assertSame('Subscription', NewsInterface::ACCESS_SUBSCRIPTION);
+
+        $this->assertSame('Satire', NewsInterface::GENRE_SATIRE);
+        $this->assertSame('Blog', NewsInterface::GENRE_BLOG);
+        $this->assertSame('OpEd', NewsInterface::GENRE_OP_ED);
+        $this->assertSame('Opinion', NewsInterface::GENRE_OPINION);
+        $this->assertSame('UserGenerated', NewsInterface::GENRE_USER_GENERATED);
+
+        $this->assertSame(5, NewsInterface::STOCK_TICKERS_MAX_COUNT);
+    }
+}

--- a/test/Component/News/NewsTest.php
+++ b/test/Component/News/NewsTest.php
@@ -18,23 +18,6 @@ class NewsTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 
-    public function testConstants()
-    {
-        $this->assertSame('xmlns:news', News::XML_NAMESPACE_ATTRIBUTE);
-        $this->assertSame('http://www.google.com/schemas/sitemap-news/0.9', News::XML_NAMESPACE_URI);
-
-        $this->assertSame('Registration', News::ACCESS_REGISTRATION);
-        $this->assertSame('Subscription', News::ACCESS_SUBSCRIPTION);
-
-        $this->assertSame('Satire', News::GENRE_SATIRE);
-        $this->assertSame('Blog', News::GENRE_BLOG);
-        $this->assertSame('OpEd', News::GENRE_OP_ED);
-        $this->assertSame('Opinion', News::GENRE_OPINION);
-        $this->assertSame('UserGenerated', News::GENRE_USER_GENERATED);
-
-        $this->assertSame(5, News::STOCK_TICKERS_MAX_COUNT);
-    }
-
     public function testImplementsInterface()
     {
         $faker = $this->getFaker();

--- a/test/Component/UrlInterfaceTest.php
+++ b/test/Component/UrlInterfaceTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+namespace Refinery29\Sitemap\Test\Component;
+
+use Refinery29\Sitemap\Component\UrlInterface;
+
+class UrlInterfaceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstants()
+    {
+        $this->assertSame('always', UrlInterface::CHANGE_FREQUENCY_ALWAYS);
+        $this->assertSame('hourly', UrlInterface::CHANGE_FREQUENCY_HOURLY);
+        $this->assertSame('daily', UrlInterface::CHANGE_FREQUENCY_DAILY);
+        $this->assertSame('weekly', UrlInterface::CHANGE_FREQUENCY_WEEKLY);
+        $this->assertSame('monthly', UrlInterface::CHANGE_FREQUENCY_MONTHLY);
+        $this->assertSame('yearly', UrlInterface::CHANGE_FREQUENCY_YEARLY);
+        $this->assertSame('never', UrlInterface::CHANGE_FREQUENCY_NEVER);
+    }
+}

--- a/test/Component/UrlSetInterfaceTest.php
+++ b/test/Component/UrlSetInterfaceTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+namespace Refinery29\Sitemap\Test\Component;
+
+use Refinery29\Sitemap\Component\UrlSetInterface;
+use Refinery29\Test\Util\Faker\GeneratorTrait;
+
+class UrlSetInterfaceTest extends \PHPUnit_Framework_TestCase
+{
+    use GeneratorTrait;
+
+    public function testConstants()
+    {
+        $this->assertSame('xmlns', UrlSetInterface::XML_NAMESPACE_ATTRIBUTE);
+        $this->assertSame('http://www.sitemaps.org/schemas/sitemap/0.9', UrlSetInterface::XML_NAMESPACE_URI);
+    }
+}

--- a/test/Component/UrlSetTest.php
+++ b/test/Component/UrlSetTest.php
@@ -16,12 +16,6 @@ class UrlSetTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 
-    public function testConstants()
-    {
-        $this->assertSame('xmlns', UrlSet::XML_NAMESPACE_ATTRIBUTE);
-        $this->assertSame('http://www.sitemaps.org/schemas/sitemap/0.9', UrlSet::XML_NAMESPACE_URI);
-    }
-
     public function testDefaults()
     {
         $urlSet = new UrlSet();

--- a/test/Component/UrlTest.php
+++ b/test/Component/UrlTest.php
@@ -19,17 +19,6 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 
-    public function testConstants()
-    {
-        $this->assertSame('always', Url::CHANGE_FREQUENCY_ALWAYS);
-        $this->assertSame('hourly', Url::CHANGE_FREQUENCY_HOURLY);
-        $this->assertSame('daily', Url::CHANGE_FREQUENCY_DAILY);
-        $this->assertSame('weekly', Url::CHANGE_FREQUENCY_WEEKLY);
-        $this->assertSame('monthly', Url::CHANGE_FREQUENCY_MONTHLY);
-        $this->assertSame('yearly', Url::CHANGE_FREQUENCY_YEARLY);
-        $this->assertSame('never', Url::CHANGE_FREQUENCY_NEVER);
-    }
-
     public function testConstructorSetsValues()
     {
         $faker = $this->getFaker();

--- a/test/Component/Video/PlatformInterfaceTest.php
+++ b/test/Component/Video/PlatformInterfaceTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+namespace Refinery29\Sitemap\Test\Component\Video;
+
+use Refinery29\Sitemap\Component\Video\PlatformInterface;
+
+class PlatformInterfaceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstants()
+    {
+        $this->assertSame('allow', PlatformInterface::RELATIONSHIP_ALLOW);
+        $this->assertSame('deny', PlatformInterface::RELATIONSHIP_DENY);
+
+        $this->assertSame('mobile', PlatformInterface::TYPE_MOBILE);
+        $this->assertSame('tv', PlatformInterface::TYPE_TV);
+        $this->assertSame('web', PlatformInterface::TYPE_WEB);
+    }
+}

--- a/test/Component/Video/PlatformTest.php
+++ b/test/Component/Video/PlatformTest.php
@@ -18,23 +18,13 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 
-    public function testConstants()
-    {
-        $this->assertSame('allow', Platform::RELATIONSHIP_ALLOW);
-        $this->assertSame('deny', Platform::RELATIONSHIP_DENY);
-
-        $this->assertSame('mobile', Platform::TYPE_MOBILE);
-        $this->assertSame('tv', Platform::TYPE_TV);
-        $this->assertSame('web', Platform::TYPE_WEB);
-    }
-
     public function testImplementsInterface()
     {
         $faker = $this->getFaker();
 
         $platform = new Platform($faker->randomElement([
-            Platform::RELATIONSHIP_ALLOW,
-            Platform::RELATIONSHIP_DENY,
+            PlatformInterface::RELATIONSHIP_ALLOW,
+            PlatformInterface::RELATIONSHIP_DENY,
         ]));
 
         $this->assertInstanceOf(PlatformInterface::class, $platform);
@@ -45,8 +35,8 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $relationship = $faker->randomElement([
-            Platform::RELATIONSHIP_ALLOW,
-            Platform::RELATIONSHIP_DENY,
+            PlatformInterface::RELATIONSHIP_ALLOW,
+            PlatformInterface::RELATIONSHIP_DENY,
         ]);
 
         $platform = new Platform($relationship);
@@ -59,8 +49,8 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $platform = new Platform($faker->randomElement([
-            Platform::RELATIONSHIP_ALLOW,
-            Platform::RELATIONSHIP_DENY,
+            PlatformInterface::RELATIONSHIP_ALLOW,
+            PlatformInterface::RELATIONSHIP_DENY,
         ]));
 
         $this->assertInternalType('array', $platform->getTypes());
@@ -79,14 +69,14 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $platform = new Platform($faker->randomElement([
-            Platform::RELATIONSHIP_ALLOW,
-            Platform::RELATIONSHIP_DENY,
+            PlatformInterface::RELATIONSHIP_ALLOW,
+            PlatformInterface::RELATIONSHIP_DENY,
         ]));
 
         $type = $faker->randomElement([
-            Platform::TYPE_MOBILE,
-            Platform::TYPE_TV,
-            Platform::TYPE_WEB,
+            PlatformInterface::TYPE_MOBILE,
+            PlatformInterface::TYPE_TV,
+            PlatformInterface::TYPE_WEB,
         ]);
 
         $platform->addType($type);
@@ -103,14 +93,14 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $platform = new Platform($faker->randomElement([
-            Platform::RELATIONSHIP_ALLOW,
-            Platform::RELATIONSHIP_DENY,
+            PlatformInterface::RELATIONSHIP_ALLOW,
+            PlatformInterface::RELATIONSHIP_DENY,
         ]));
 
         $type = $faker->randomElement([
-            Platform::TYPE_MOBILE,
-            Platform::TYPE_TV,
-            Platform::TYPE_WEB,
+            PlatformInterface::TYPE_MOBILE,
+            PlatformInterface::TYPE_TV,
+            PlatformInterface::TYPE_WEB,
         ]);
 
         $platform->addType($type);
@@ -124,8 +114,8 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $platform = new Platform($faker->randomElement([
-            Platform::RELATIONSHIP_ALLOW,
-            Platform::RELATIONSHIP_DENY,
+            PlatformInterface::RELATIONSHIP_ALLOW,
+            PlatformInterface::RELATIONSHIP_DENY,
         ]));
 
         $platform->addType('foobarbaz');

--- a/test/Component/Video/PlayerLocationInterfaceTest.php
+++ b/test/Component/Video/PlayerLocationInterfaceTest.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+namespace Refinery29\Sitemap\Test\Component\Video;
+
+use Refinery29\Sitemap\Component\Video\PlayerLocationInterface;
+
+class PlayerLocationInterfaceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstants()
+    {
+        $this->assertSame('yes', PlayerLocationInterface::ALLOW_EMBED_YES);
+        $this->assertSame('no', PlayerLocationInterface::ALLOW_EMBED_NO);
+    }
+}

--- a/test/Component/Video/PlayerLocationTest.php
+++ b/test/Component/Video/PlayerLocationTest.php
@@ -19,8 +19,8 @@ class PlayerLocationTest extends \PHPUnit_Framework_TestCase
 
     public function testConstants()
     {
-        $this->assertSame('yes', PlayerLocation::ALLOW_EMBED_YES);
-        $this->assertSame('no', PlayerLocation::ALLOW_EMBED_NO);
+        $this->assertSame('yes', PlayerLocationInterface::ALLOW_EMBED_YES);
+        $this->assertSame('no', PlayerLocationInterface::ALLOW_EMBED_NO);
     }
 
     public function testImplementsInterface()
@@ -36,8 +36,8 @@ class PlayerLocationTest extends \PHPUnit_Framework_TestCase
 
         $location = $faker->url;
         $allowEmbed = $faker->randomElement([
-            PlayerLocation::ALLOW_EMBED_NO,
-            PlayerLocation::ALLOW_EMBED_YES,
+            PlayerLocationInterface::ALLOW_EMBED_NO,
+            PlayerLocationInterface::ALLOW_EMBED_YES,
         ]);
         $autoPlay = 'play=true';
 

--- a/test/Component/Video/PriceInterfaceTest.php
+++ b/test/Component/Video/PriceInterfaceTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+namespace Refinery29\Sitemap\Test\Component\Video;
+
+use Refinery29\Sitemap\Component\Video\PriceInterface;
+
+class PriceInterfaceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstants()
+    {
+        $this->assertSame('own', PriceInterface::TYPE_OWN);
+        $this->assertSame('rent', PriceInterface::TYPE_RENT);
+
+        $this->assertSame('HD', PriceInterface::RESOLUTION_HD);
+        $this->assertSame('SD', PriceInterface::RESOLUTION_SD);
+    }
+}

--- a/test/Component/Video/PriceTest.php
+++ b/test/Component/Video/PriceTest.php
@@ -19,11 +19,11 @@ class PriceTest extends \PHPUnit_Framework_TestCase
 
     public function testConstants()
     {
-        $this->assertSame('own', Price::TYPE_OWN);
-        $this->assertSame('rent', Price::TYPE_RENT);
+        $this->assertSame('own', PriceInterface::TYPE_OWN);
+        $this->assertSame('rent', PriceInterface::TYPE_RENT);
 
-        $this->assertSame('HD', Price::RESOLUTION_HD);
-        $this->assertSame('SD', Price::RESOLUTION_SD);
+        $this->assertSame('HD', PriceInterface::RESOLUTION_HD);
+        $this->assertSame('SD', PriceInterface::RESOLUTION_SD);
     }
 
     public function testImplementsInterface()
@@ -45,12 +45,12 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         $value = $faker->randomFloat(2, 0.01);
         $currency = $faker->currencyCode;
         $type = $faker->randomElement([
-            Price::TYPE_OWN,
-            Price::TYPE_RENT,
+            PriceInterface::TYPE_OWN,
+            PriceInterface::TYPE_RENT,
         ]);
         $resolution = $faker->randomElement([
-            Price::RESOLUTION_HD,
-            Price::RESOLUTION_SD,
+            PriceInterface::RESOLUTION_HD,
+            PriceInterface::RESOLUTION_SD,
         ]);
 
         $price = new Price(
@@ -116,7 +116,7 @@ class PriceTest extends \PHPUnit_Framework_TestCase
     {
         $invalidValues = [
             'foo',
-            Price::VALUE_MIN - 0.01,
+            PriceInterface::VALUE_MIN - 0.01,
         ];
 
         foreach ($invalidValues as $value) {
@@ -136,8 +136,8 @@ class PriceTest extends \PHPUnit_Framework_TestCase
             $faker->randomFloat(2, 0.01),
             $faker->currencyCode,
             $faker->randomElement([
-                Price::TYPE_OWN,
-                Price::TYPE_RENT,
+                PriceInterface::TYPE_OWN,
+                PriceInterface::TYPE_RENT,
             ]),
             'foobarbaz'
 

--- a/test/Component/Video/RestrictionInterfaceTest.php
+++ b/test/Component/Video/RestrictionInterfaceTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+namespace Refinery29\Sitemap\Test\Component\Video;
+
+use Refinery29\Sitemap\Component\Video\RestrictionInterface;
+use Refinery29\Test\Util\Faker\GeneratorTrait;
+
+class RestrictionInterfaceTest extends \PHPUnit_Framework_TestCase
+{
+    use GeneratorTrait;
+
+    public function testConstants()
+    {
+        $this->assertSame('allow', RestrictionInterface::RELATIONSHIP_ALLOW);
+        $this->assertSame('deny', RestrictionInterface::RELATIONSHIP_DENY);
+    }
+}

--- a/test/Component/Video/VideoInterfaceTest.php
+++ b/test/Component/Video/VideoInterfaceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+namespace Refinery29\Sitemap\Test\Component\Video;
+
+use Refinery29\Sitemap\Component\Video\VideoInterface;
+
+class VideoInterfaceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstants()
+    {
+        $this->assertSame('xmlns:video', VideoInterface::XML_NAMESPACE_ATTRIBUTE);
+        $this->assertSame('http://www.google.com/schemas/sitemap-video/1.1', VideoInterface::XML_NAMESPACE_URI);
+
+        $this->assertSame(100, VideoInterface::TITLE_MAX_LENGTH);
+
+        $this->assertSame(0, VideoInterface::DURATION_LOWER_LIMIT);
+        $this->assertSame(28800, VideoInterface::DURATION_UPPER_LIMIT);
+
+        $this->assertSame(0.0, VideoInterface::RATING_MIN);
+        $this->assertSame(5.0, VideoInterface::RATING_MAX);
+
+        $this->assertSame('yes', VideoInterface::REQUIRES_SUBSCRIPTION_YES);
+        $this->assertSame('no', VideoInterface::REQUIRES_SUBSCRIPTION_NO);
+
+        $this->assertSame('no', VideoInterface::FAMILY_FRIENDLY_NO);
+
+        $this->assertSame(256, VideoInterface::CATEGORY_MAX_LENGTH);
+
+        $this->assertSame(32, VideoInterface::TAG_MAX_COUNT);
+    }
+}

--- a/test/Writer/Video/PlayerLocationWriterTest.php
+++ b/test/Writer/Video/PlayerLocationWriterTest.php
@@ -8,7 +8,6 @@
  */
 namespace Refinery29\Sitemap\Test\Writer\Video;
 
-use Refinery29\Sitemap\Component\Video\PlayerLocation;
 use Refinery29\Sitemap\Component\Video\PlayerLocationInterface;
 use Refinery29\Sitemap\Test\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\Video\PlayerLocationWriter;
@@ -39,8 +38,8 @@ class PlayerLocationWriterTest extends AbstractTestCase
 
         $location = $faker->url;
         $allowEmbed = $faker->randomElement([
-            PlayerLocation::ALLOW_EMBED_NO,
-            PlayerLocation::ALLOW_EMBED_YES,
+            PlayerLocationInterface::ALLOW_EMBED_NO,
+            PlayerLocationInterface::ALLOW_EMBED_YES,
         ]);
         $autoPlay = 'play=yes';
 

--- a/test/Writer/Video/PriceWriterTest.php
+++ b/test/Writer/Video/PriceWriterTest.php
@@ -8,7 +8,6 @@
  */
 namespace Refinery29\Sitemap\Test\Writer\Video;
 
-use Refinery29\Sitemap\Component\Video\Price;
 use Refinery29\Sitemap\Component\Video\PriceInterface;
 use Refinery29\Sitemap\Test\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\Video\PriceWriter;
@@ -46,12 +45,12 @@ class PriceWriterTest extends AbstractTestCase
         $currency = $faker->currencyCode;
         $value = $faker->randomFloat(2, 0.01);
         $type = $faker->randomElement([
-            Price::TYPE_OWN,
-            Price::TYPE_RENT,
+            PriceInterface::TYPE_OWN,
+            PriceInterface::TYPE_RENT,
         ]);
         $resolution = $faker->randomElement([
-            Price::RESOLUTION_HD,
-            Price::RESOLUTION_SD,
+            PriceInterface::RESOLUTION_HD,
+            PriceInterface::RESOLUTION_SD,
         ]);
 
         $price = $this->getPriceMock(


### PR DESCRIPTION
This PR

* [x] moves constants from implementations to interfaces

:information_desk_person: The idea is this:

* actual resources of documentation are linked from interfaces
* someone using the package may want to implement interfaces differently, and then it would make more sense for them to reference the interface only, not an actual implementation, too