### PR TITLE
Enhancement: Use beberlei/assert to guard against invalid values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^5.5 || ^7.0"
+        "php": "^5.5 || ^7.0",
+        "beberlei/assert": "^2.4"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "0.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,63 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1cb6c636a532bff6823fdf02b92f766d",
-    "content-hash": "22a758d99dd43f9f839301b6e874a6f4",
-    "packages": [],
+    "hash": "bd1133a880c14c84e2855de8bf2c2e1d",
+    "content-hash": "bca3f5e71e0a54bd5395626701808dd2",
+    "packages": [
+        {
+            "name": "beberlei/assert",
+            "version": "v2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beberlei/assert.git",
+                "reference": "7281b1fd8118b31cb9162c2fb5a4cc6f01d62ed6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/7281b1fd8118b31cb9162c2fb5a4cc6f01d62ed6",
+                "reference": "7281b1fd8118b31cb9162c2fb5a4cc6f01d62ed6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "@stable"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Assert": "lib/"
+                },
+                "files": [
+                    "lib/Assert/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [
+                "assert",
+                "assertion",
+                "validation"
+            ],
+            "time": "2015-08-21 16:50:17"
+        }
+    ],
     "packages-dev": [
         {
             "name": "codeclimate/php-test-reporter",

--- a/src/Component/News/News.php
+++ b/src/Component/News/News.php
@@ -8,8 +8,8 @@
  */
 namespace Refinery29\Sitemap\Component\News;
 
+use Assert\Assertion;
 use DateTime;
-use InvalidArgumentException;
 
 final class News implements NewsInterface
 {
@@ -98,22 +98,12 @@ final class News implements NewsInterface
      */
     private function setAccess($access = null)
     {
-        if ($access === null) {
-            return;
-        }
-
         $allowedValues = [
             NewsInterface::ACCESS_REGISTRATION,
             NewsInterface::ACCESS_SUBSCRIPTION,
         ];
 
-        if (!in_array($access, $allowedValues)) {
-            throw new InvalidArgumentException(sprintf(
-                'Optional parameter "%s" needs to be specified as one of "%s"',
-                'access',
-                implode('", "', $allowedValues)
-            ));
-        }
+        Assertion::nullOrChoice($access, $allowedValues);
 
         $this->access = $access;
     }
@@ -128,10 +118,6 @@ final class News implements NewsInterface
      */
     private function setGenres(array $genres = [])
     {
-        if (!count($genres)) {
-            return;
-        }
-
         $allowedValues = [
             NewsInterface::GENRE_BLOG,
             NewsInterface::GENRE_OP_ED,
@@ -140,17 +126,7 @@ final class News implements NewsInterface
             NewsInterface::GENRE_USER_GENERATED,
         ];
 
-        $invalidValues = array_filter($genres, function ($genre) use ($allowedValues) {
-            return !in_array($genre, $allowedValues, true);
-        });
-
-        if (count($invalidValues)) {
-            throw new InvalidArgumentException(sprintf(
-                'Optional parameter "%s" needs to be specified as an array, and each element needs to be one of "%s"',
-                'genres',
-                implode('", "', $allowedValues)
-            ));
-        }
+        Assertion::allChoice($genres, $allowedValues);
 
         $this->genres = $genres;
     }
@@ -170,17 +146,7 @@ final class News implements NewsInterface
      */
     private function setStockTickers(array $stockTickers = [])
     {
-        if (!count($stockTickers)) {
-            return;
-        }
-
-        if (count($stockTickers) > NewsInterface::STOCK_TICKERS_MAX_COUNT) {
-            throw new InvalidArgumentException(sprintf(
-                'Optional parameter "%s" needs to be specified as an array with at most "%s" elements',
-                'stockTickers',
-                NewsInterface::STOCK_TICKERS_MAX_COUNT
-            ));
-        }
+        Assertion::lessOrEqualThan(count($stockTickers), NewsInterface::STOCK_TICKERS_MAX_COUNT);
 
         $this->stockTickers = $stockTickers;
     }

--- a/src/Component/Url.php
+++ b/src/Component/Url.php
@@ -8,8 +8,8 @@
  */
 namespace Refinery29\Sitemap\Component;
 
+use Assert\Assertion;
 use DateTime;
-use InvalidArgumentException;
 use Refinery29\Sitemap\Component\Image\ImageInterface;
 use Refinery29\Sitemap\Component\News\NewsInterface;
 use Refinery29\Sitemap\Component\Video\VideoInterface;
@@ -94,12 +94,7 @@ final class Url implements UrlInterface
      */
     public function addImage(ImageInterface $image)
     {
-        if (count($this->images) === UrlInterface::IMAGE_MAX_COUNT) {
-            throw new InvalidArgumentException(sprintf(
-                'Can not add more than %s images',
-                UrlInterface::IMAGE_MAX_COUNT
-            ));
-        }
+        Assertion::lessThan(count($this->images), UrlInterface::IMAGE_MAX_COUNT);
 
         $this->images[] = $image;
     }

--- a/src/Component/Video/Platform.php
+++ b/src/Component/Video/Platform.php
@@ -8,7 +8,7 @@
  */
 namespace Refinery29\Sitemap\Component\Video;
 
-use InvalidArgumentException;
+use Assert\Assertion;
 
 final class Platform implements PlatformInterface
 {
@@ -40,13 +40,7 @@ final class Platform implements PlatformInterface
             PlatformInterface::RELATIONSHIP_DENY,
         ];
 
-        if (!is_string($relationship) || !in_array($relationship, $allowedValues)) {
-            throw new InvalidArgumentException(sprintf(
-                'Parameter "%s" needs to be specified as one of "%s"',
-                'relationship',
-                implode('", "', $allowedValues)
-            ));
-        }
+        Assertion::choice($relationship, $allowedValues);
 
         $this->relationship = $relationship;
     }
@@ -67,17 +61,8 @@ final class Platform implements PlatformInterface
             PlatformInterface::TYPE_WEB,
         ];
 
-        if (!is_string($type) || !in_array($type, $allowedValues)) {
-            throw new InvalidArgumentException(sprintf(
-                'Parameter "%s" needs to be specified as one of "%s"',
-                'type',
-                implode('", "', $allowedValues)
-            ));
-        }
-
-        if (in_array($type, $this->types)) {
-            throw new InvalidArgumentException('Can not add the same type twice');
-        }
+        Assertion::choice($type, $allowedValues);
+        Assertion::false(in_array($type, $this->types));
 
         $this->types[] = $type;
     }

--- a/src/Component/Video/PlayerLocation.php
+++ b/src/Component/Video/PlayerLocation.php
@@ -8,7 +8,7 @@
  */
 namespace Refinery29\Sitemap\Component\Video;
 
-use InvalidArgumentException;
+use Assert\Assertion;
 
 final class PlayerLocation implements PlayerLocationInterface
 {
@@ -51,22 +51,12 @@ final class PlayerLocation implements PlayerLocationInterface
      */
     private function setAllowEmbed($allowEmbed = null)
     {
-        if ($allowEmbed === null) {
-            return;
-        }
-
         $allowedValues = [
             PlayerLocationInterface::ALLOW_EMBED_NO,
             PlayerLocationInterface::ALLOW_EMBED_YES,
         ];
 
-        if (!in_array($allowEmbed, $allowedValues)) {
-            throw new InvalidArgumentException(sprintf(
-                'Optional parameter "%s" needs to be specified as one of "%s"',
-                'allowEmbed',
-                implode('", "', $allowedValues)
-            ));
-        }
+        Assertion::nullOrChoice($allowEmbed, $allowedValues);
 
         $this->allowEmbed = $allowEmbed;
     }

--- a/src/Component/Video/Price.php
+++ b/src/Component/Video/Price.php
@@ -8,7 +8,7 @@
  */
 namespace Refinery29\Sitemap\Component\Video;
 
-use InvalidArgumentException;
+use Assert\Assertion;
 
 final class Price implements PriceInterface
 {
@@ -53,13 +53,7 @@ final class Price implements PriceInterface
      */
     private function setValue($value)
     {
-        if (!is_numeric($value) || $value < PriceInterface::VALUE_MIN) {
-            throw new InvalidArgumentException(sprintf(
-                'Parameter "%s" needs to be specified as a number greater than "%s"',
-                $value,
-                PriceInterface::VALUE_MIN
-            ));
-        }
+        Assertion::greaterOrEqualThan($value, PriceInterface::VALUE_MIN);
 
         $this->value = $value;
     }
@@ -79,22 +73,12 @@ final class Price implements PriceInterface
      */
     private function setType($type = null)
     {
-        if ($type === null) {
-            return;
-        }
-
         $allowedValues = [
             PriceInterface::TYPE_OWN,
             PriceInterface::TYPE_RENT,
         ];
 
-        if (!is_string($type) || !in_array($type, $allowedValues)) {
-            throw new InvalidArgumentException(sprintf(
-                'Optional parameter "%s" needs to be specified as one of "%s"',
-                'type',
-                implode('", "', $allowedValues)
-            ));
-        }
+        Assertion::nullOrChoice($type, $allowedValues);
 
         $this->type = $type;
     }
@@ -109,22 +93,12 @@ final class Price implements PriceInterface
      */
     private function setResolution($resolution = null)
     {
-        if ($resolution === null) {
-            return;
-        }
-
         $allowedValues = [
             PriceInterface::RESOLUTION_HD,
             PriceInterface::RESOLUTION_SD,
         ];
 
-        if (!is_string($resolution) || !in_array($resolution, $allowedValues)) {
-            throw new InvalidArgumentException(sprintf(
-                'Optional parameter "%s" needs to be specified as one of "%s"',
-                'resolution',
-                implode('", "', $allowedValues)
-            ));
-        }
+        Assertion::nullOrChoice($resolution, $allowedValues);
 
         $this->resolution = $resolution;
     }

--- a/src/Component/Video/Restriction.php
+++ b/src/Component/Video/Restriction.php
@@ -8,6 +8,8 @@
  */
 namespace Refinery29\Sitemap\Component\Video;
 
+use Assert\Assertion;
+
 final class Restriction implements RestrictionInterface
 {
     /**
@@ -38,13 +40,7 @@ final class Restriction implements RestrictionInterface
             RestrictionInterface::RELATIONSHIP_DENY,
         ];
 
-        if (!is_string($relationship) || !in_array($relationship, $allowedValues)) {
-            throw new \InvalidArgumentException(sprintf(
-                'Parameter "%s" needs to be specified as one of "%s"',
-                'relationship',
-                implode('", "', $allowedValues)
-            ));
-        }
+        Assertion::choice($relationship, $allowedValues);
 
         $this->relationship = $relationship;
     }

--- a/src/Component/Video/Video.php
+++ b/src/Component/Video/Video.php
@@ -8,8 +8,8 @@
  */
 namespace Refinery29\Sitemap\Component\Video;
 
+use Assert\Assertion;
 use DateTime;
-use InvalidArgumentException;
 
 final class Video implements VideoInterface
 {
@@ -158,15 +158,13 @@ final class Video implements VideoInterface
         $this->setTitle($title);
         $this->setDescription($description);
 
-        if ($contentLocation === null && $playerLocation === null) {
-            throw new InvalidArgumentException(sprintf(
-                'At least one of parameters "%s" needs to be specified',
-                implode('", "', [
-                    'contentLocation',
-                    'playerLocation',
-                ])
-            ));
-        }
+        Assertion::false($contentLocation === null && $playerLocation === null, sprintf(
+            'At least one of parameters "%s" needs to be specified',
+            implode('", "', [
+                'contentLocation',
+                'playerLocation',
+            ])
+        ));
 
         $this->contentLocation = $contentLocation;
         $this->playerLocation = $playerLocation;
@@ -202,13 +200,7 @@ final class Video implements VideoInterface
      */
     private function setTitle($title)
     {
-        if (!is_string($title) || mb_strlen($title) > VideoInterface::TITLE_MAX_LENGTH) {
-            throw new InvalidArgumentException(sprintf(
-                'Parameter "%s" needs to be specified as a string not longer than "%s" characters',
-                'title',
-                VideoInterface::TITLE_MAX_LENGTH
-            ));
-        }
+        Assertion::maxLength($title, VideoInterface::TITLE_MAX_LENGTH);
 
         $this->title = $title;
     }
@@ -223,13 +215,7 @@ final class Video implements VideoInterface
      */
     private function setDescription($description)
     {
-        if (!is_string($description) || mb_strlen($description) > VideoInterface::DESCRIPTION_MAX_LENGTH) {
-            throw new InvalidArgumentException(sprintf(
-                'Optional parameter "%s" needs to be specified as a string not longer than "%s" characters',
-                'description',
-                VideoInterface::DESCRIPTION_MAX_LENGTH
-            ));
-        }
+        Assertion::maxLength($description, VideoInterface::DESCRIPTION_MAX_LENGTH);
 
         $this->description = $description;
     }
@@ -259,17 +245,11 @@ final class Video implements VideoInterface
      */
     private function setDuration($duration = null)
     {
-        if ($duration === null) {
-            return;
-        }
+        Assertion::nullOrInteger($duration);
 
-        if (!is_int($duration) || $duration <= VideoInterface::DURATION_LOWER_LIMIT || $duration >= VideoInterface::DURATION_UPPER_LIMIT) {
-            throw new InvalidArgumentException(sprintf(
-                'Optional parameter "%s" needs to be specified as an integer greater than "%s" and smaller than "%s"',
-                'duration',
-                VideoInterface::DURATION_LOWER_LIMIT,
-                VideoInterface::DURATION_UPPER_LIMIT
-            ));
+        if ($duration !== null) {
+            Assertion::greaterThan($duration, VideoInterface::DURATION_LOWER_LIMIT);
+            Assertion::lessThan($duration, VideoInterface::DURATION_UPPER_LIMIT);
         }
 
         $this->duration = $duration;
@@ -303,17 +283,11 @@ final class Video implements VideoInterface
      */
     private function setRating($rating = null)
     {
-        if ($rating === null) {
-            return;
-        }
+        Assertion::nullOrNumeric($rating);
 
-        if (!is_numeric($rating) || $rating < VideoInterface::RATING_MIN || $rating > VideoInterface::RATING_MAX) {
-            throw new InvalidArgumentException(sprintf(
-                'Optional parameter "%s" needs to be specified as a number not smaller than "%s" and not greater than "%s"',
-                'rating',
-                VideoInterface::RATING_MIN,
-                VideoInterface::RATING_MAX
-            ));
+        if ($rating !== null) {
+            Assertion::greaterOrEqualThan($rating, VideoInterface::RATING_MIN);
+            Assertion::lessOrEqualThan($rating, VideoInterface::RATING_MAX);
         }
 
         $this->rating = $rating;
@@ -329,16 +303,10 @@ final class Video implements VideoInterface
      */
     private function setViewCount($viewCount = null)
     {
-        if ($viewCount === null) {
-            return;
-        }
+        Assertion::nullOrInteger($viewCount);
 
-        if (!is_int($viewCount) || $viewCount < 0) {
-            throw new InvalidArgumentException(sprintf(
-                'Optional parameter "%s" needs to be specified as an integer not less than "%s"',
-                'viewCount',
-                0
-            ));
+        if ($viewCount !== null) {
+            Assertion::greaterOrEqualThan($viewCount, 0);
         }
 
         $this->viewCount = $viewCount;
@@ -354,17 +322,11 @@ final class Video implements VideoInterface
      */
     private function setFamilyFriendly($familyFriendly = null)
     {
-        if ($familyFriendly === null) {
-            return;
-        }
+        $choices = [
+            VideoInterface::FAMILY_FRIENDLY_NO,
+        ];
 
-        if ($familyFriendly !== VideoInterface::FAMILY_FRIENDLY_NO) {
-            throw new InvalidArgumentException(sprintf(
-                'Optional parameter "%s" needs to be specified as "%s"',
-                'familyFriendly',
-                VideoInterface::FAMILY_FRIENDLY_NO
-            ));
-        }
+        Assertion::nullOrChoice($familyFriendly, $choices);
 
         $this->familyFriendly = $familyFriendly;
     }
@@ -379,12 +341,7 @@ final class Video implements VideoInterface
      */
     public function addTag(TagInterface $tag)
     {
-        if (count($this->tags) === VideoInterface::TAG_MAX_COUNT) {
-            throw new InvalidArgumentException(sprintf(
-                'Can not add more than %s tags',
-                VideoInterface::TAG_MAX_COUNT
-            ));
-        }
+        Assertion::lessThan(count($this->tags), VideoInterface::TAG_MAX_COUNT);
 
         $this->tags[] = $tag;
     }
@@ -399,16 +356,10 @@ final class Video implements VideoInterface
      */
     private function setCategory($category = null)
     {
-        if ($category === null) {
-            return;
-        }
+        Assertion::nullOrString($category);
 
-        if (!is_string($category) || mb_strlen($category) > VideoInterface::CATEGORY_MAX_LENGTH) {
-            throw new InvalidArgumentException(sprintf(
-                'Optional parameter "%s" needs to be specified as a string not longer than "%s" characters',
-                'category',
-                VideoInterface::CATEGORY_MAX_LENGTH
-            ));
+        if ($category !== null) {
+            Assertion::maxLength($category, VideoInterface::CATEGORY_MAX_LENGTH);
         }
 
         $this->category = $category;
@@ -442,22 +393,12 @@ final class Video implements VideoInterface
      */
     private function setRequiresSubscription($requiresSubscription = null)
     {
-        if ($requiresSubscription === null) {
-            return;
-        }
-
         $allowedValues = [
             VideoInterface::REQUIRES_SUBSCRIPTION_NO,
             VideoInterface::REQUIRES_SUBSCRIPTION_YES,
         ];
 
-        if (!is_string($requiresSubscription) || !in_array($requiresSubscription, $allowedValues)) {
-            throw new InvalidArgumentException(sprintf(
-                'Optional parameter "%s" needs to be specified as one of "%s"',
-                'requiresSubscription',
-                implode('", "', $allowedValues)
-            ));
-        }
+        Assertion::nullOrChoice($requiresSubscription, $allowedValues);
 
         $this->requiresSubscription = $requiresSubscription;
     }
@@ -482,22 +423,12 @@ final class Video implements VideoInterface
      */
     private function setLive($live = null)
     {
-        if ($live === null) {
-            return;
-        }
-
         $allowedValues = [
             VideoInterface::LIVE_NO,
             VideoInterface::LIVE_YES,
         ];
 
-        if (!is_string($live) || !in_array($live, $allowedValues)) {
-            throw new InvalidArgumentException(sprintf(
-                'Optional parameter "%s" needs to be specified as one of "%s"',
-                'live',
-                implode('", "', $allowedValues)
-            ));
-        }
+        Assertion::nullOrChoice($live, $allowedValues);
 
         $this->live = $live;
     }


### PR DESCRIPTION
This PR

* [x] requires `beberlei/assert`  
* [x] uses assertions to guard against invalid values being passed in

