### PR TITLE
Fix: Actually use constants defined in interfaces

### DIFF
--- a/test/Component/News/NewsTest.php
+++ b/test/Component/News/NewsTest.php
@@ -39,18 +39,18 @@ class NewsTest extends \PHPUnit_Framework_TestCase
         $publicationDate = $faker->dateTime;
         $title = $faker->sentence();
         $access = $faker->randomElement([
-            News::ACCESS_REGISTRATION,
-            News::ACCESS_SUBSCRIPTION,
+            NewsInterface::ACCESS_REGISTRATION,
+            NewsInterface::ACCESS_SUBSCRIPTION,
         ]);
         $genres = $faker->randomElements([
-            News::GENRE_BLOG,
-            News::GENRE_OP_ED,
-            News::GENRE_OPINION,
-            News::GENRE_SATIRE,
-            News::GENRE_USER_GENERATED,
+            NewsInterface::GENRE_BLOG,
+            NewsInterface::GENRE_OP_ED,
+            NewsInterface::GENRE_OPINION,
+            NewsInterface::GENRE_SATIRE,
+            NewsInterface::GENRE_USER_GENERATED,
         ]);
         $keywords = $faker->words;
-        $stockTickers = $faker->words(News::STOCK_TICKERS_MAX_COUNT);
+        $stockTickers = $faker->words(NewsInterface::STOCK_TICKERS_MAX_COUNT);
 
         $news = new News(
             $publication,
@@ -120,8 +120,8 @@ class NewsTest extends \PHPUnit_Framework_TestCase
     {
         $allowedValues = [
             null,
-            News::ACCESS_REGISTRATION,
-            News::ACCESS_SUBSCRIPTION,
+            NewsInterface::ACCESS_REGISTRATION,
+            NewsInterface::ACCESS_SUBSCRIPTION,
         ];
 
         foreach ($allowedValues as $access) {
@@ -159,8 +159,8 @@ class NewsTest extends \PHPUnit_Framework_TestCase
             $faker->dateTime,
             $faker->sentence(),
             $faker->randomElement([
-                News::ACCESS_REGISTRATION,
-                News::ACCESS_SUBSCRIPTION,
+                NewsInterface::ACCESS_REGISTRATION,
+                NewsInterface::ACCESS_SUBSCRIPTION,
             ]),
             $genres
         );
@@ -174,11 +174,11 @@ class NewsTest extends \PHPUnit_Framework_TestCase
     public function providerCanInjectGenres()
     {
         $allowedValues = [
-            News::GENRE_BLOG,
-            News::GENRE_OP_ED,
-            News::GENRE_OPINION,
-            News::GENRE_SATIRE,
-            News::GENRE_USER_GENERATED,
+            NewsInterface::GENRE_BLOG,
+            NewsInterface::GENRE_OP_ED,
+            NewsInterface::GENRE_OPINION,
+            NewsInterface::GENRE_SATIRE,
+            NewsInterface::GENRE_USER_GENERATED,
         ];
 
         $faker = $this->getFaker();
@@ -205,8 +205,8 @@ class NewsTest extends \PHPUnit_Framework_TestCase
             $faker->dateTime,
             $faker->sentence(),
             $faker->randomElement([
-                News::ACCESS_REGISTRATION,
-                News::ACCESS_SUBSCRIPTION,
+                NewsInterface::ACCESS_REGISTRATION,
+                NewsInterface::ACCESS_SUBSCRIPTION,
             ]),
             $genres
         );
@@ -218,22 +218,22 @@ class NewsTest extends \PHPUnit_Framework_TestCase
 
         $faker = $this->getFaker();
 
-        $stockTickers = $faker->words(News::STOCK_TICKERS_MAX_COUNT + 1);
+        $stockTickers = $faker->words(NewsInterface::STOCK_TICKERS_MAX_COUNT + 1);
 
         new News(
             $this->getPublicationMock(),
             $faker->dateTime,
             $faker->sentence(),
             $faker->randomElement([
-                News::ACCESS_REGISTRATION,
-                News::ACCESS_SUBSCRIPTION,
+                NewsInterface::ACCESS_REGISTRATION,
+                NewsInterface::ACCESS_SUBSCRIPTION,
             ]),
             $faker->randomElements([
-                News::GENRE_BLOG,
-                News::GENRE_OP_ED,
-                News::GENRE_OPINION,
-                News::GENRE_SATIRE,
-                News::GENRE_USER_GENERATED,
+                NewsInterface::GENRE_BLOG,
+                NewsInterface::GENRE_OP_ED,
+                NewsInterface::GENRE_OPINION,
+                NewsInterface::GENRE_SATIRE,
+                NewsInterface::GENRE_USER_GENERATED,
             ]),
             $faker->words,
             $stockTickers

--- a/test/Component/Video/RestrictionTest.php
+++ b/test/Component/Video/RestrictionTest.php
@@ -17,17 +17,11 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 
-    public function testConstants()
-    {
-        $this->assertSame('allow', Restriction::RELATIONSHIP_ALLOW);
-        $this->assertSame('deny', Restriction::RELATIONSHIP_DENY);
-    }
-
     public function testImplementsInterface()
     {
         $restriction = new Restriction($this->getFaker()->randomElement([
-            Restriction::RELATIONSHIP_ALLOW,
-            Restriction::RELATIONSHIP_DENY,
+            RestrictionInterface::RELATIONSHIP_ALLOW,
+            RestrictionInterface::RELATIONSHIP_DENY,
         ]));
 
         $this->assertInstanceOf(RestrictionInterface::class, $restriction);
@@ -36,8 +30,8 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
     public function testConstructorSetsValues()
     {
         $relationship = $this->getFaker()->randomElement([
-            Restriction::RELATIONSHIP_ALLOW,
-            Restriction::RELATIONSHIP_DENY,
+            RestrictionInterface::RELATIONSHIP_ALLOW,
+            RestrictionInterface::RELATIONSHIP_DENY,
         ]);
 
         $restriction = new Restriction($relationship);
@@ -48,8 +42,8 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
     public function testDefaults()
     {
         $relationship = $this->getFaker()->randomElement([
-            Restriction::RELATIONSHIP_ALLOW,
-            Restriction::RELATIONSHIP_DENY,
+            RestrictionInterface::RELATIONSHIP_ALLOW,
+            RestrictionInterface::RELATIONSHIP_DENY,
         ]);
 
         $restriction = new Restriction($relationship);
@@ -75,8 +69,8 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
         ];
 
         $relationship = $faker->randomElement([
-            Restriction::RELATIONSHIP_ALLOW,
-            Restriction::RELATIONSHIP_DENY,
+            RestrictionInterface::RELATIONSHIP_ALLOW,
+            RestrictionInterface::RELATIONSHIP_DENY,
         ]);
 
         $restriction = new Restriction($relationship);

--- a/test/Component/Video/VideoTest.php
+++ b/test/Component/Video/VideoTest.php
@@ -25,29 +25,6 @@ class VideoTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 
-    public function testConstants()
-    {
-        $this->assertSame('xmlns:video', Video::XML_NAMESPACE_ATTRIBUTE);
-        $this->assertSame('http://www.google.com/schemas/sitemap-video/1.1', Video::XML_NAMESPACE_URI);
-
-        $this->assertSame(100, Video::TITLE_MAX_LENGTH);
-
-        $this->assertSame(0, Video::DURATION_LOWER_LIMIT);
-        $this->assertSame(28800, Video::DURATION_UPPER_LIMIT);
-
-        $this->assertSame(0.0, Video::RATING_MIN);
-        $this->assertSame(5.0, Video::RATING_MAX);
-
-        $this->assertSame('yes', Video::REQUIRES_SUBSCRIPTION_YES);
-        $this->assertSame('no', Video::REQUIRES_SUBSCRIPTION_NO);
-
-        $this->assertSame('no', Video::FAMILY_FRIENDLY_NO);
-
-        $this->assertSame(256, Video::CATEGORY_MAX_LENGTH);
-
-        $this->assertSame(32, Video::TAG_MAX_COUNT);
-    }
-
     public function testImplementsInterface()
     {
         $faker = $this->getFaker();
@@ -73,25 +50,25 @@ class VideoTest extends \PHPUnit_Framework_TestCase
         $playerLocation = $this->getPlayerLocationMock();
         $galleryLocation = $this->getGalleryLocationMock();
         $duration = $faker->numberBetween(
-            Video::DURATION_LOWER_LIMIT,
-            Video::DURATION_UPPER_LIMIT
+            VideoInterface::DURATION_LOWER_LIMIT,
+            VideoInterface::DURATION_UPPER_LIMIT
         );
         $publicationDate = $faker->dateTime;
         $expirationDate = $faker->dateTime;
         $rating = $faker->randomFloat(1, 0, 5);
         $viewCount = $faker->randomNumber();
-        $familyFriendly = Video::FAMILY_FRIENDLY_NO;
+        $familyFriendly = VideoInterface::FAMILY_FRIENDLY_NO;
         $category = $faker->word;
         $restriction = $this->getRestrictionMock();
         $requiresSubscription = $faker->randomElement([
-            Video::REQUIRES_SUBSCRIPTION_YES,
-            Video::REQUIRES_SUBSCRIPTION_NO,
+            VideoInterface::REQUIRES_SUBSCRIPTION_YES,
+            VideoInterface::REQUIRES_SUBSCRIPTION_NO,
         ]);
         $uploader = $this->getUploaderMock();
         $platform = $this->getPlatformMock();
         $live = $faker->randomElement([
-            Video::LIVE_NO,
-            Video::LIVE_YES,
+            VideoInterface::LIVE_NO,
+            VideoInterface::LIVE_YES,
         ]);
 
         $video = new Video(
@@ -173,7 +150,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
 
         $faker = $this->getFaker();
 
-        $title = str_repeat('a', Video::TITLE_MAX_LENGTH + 1);
+        $title = str_repeat('a', VideoInterface::TITLE_MAX_LENGTH + 1);
 
         new Video(
             $faker->url,
@@ -189,7 +166,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
 
         $faker = $this->getFaker();
 
-        $description = str_repeat('a', Video::DESCRIPTION_MAX_LENGTH + 1);
+        $description = str_repeat('a', VideoInterface::DESCRIPTION_MAX_LENGTH + 1);
 
         new Video(
             $faker->url,
@@ -243,10 +220,10 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     {
         $invalidValues = [
             'foo',
-            Video::DURATION_LOWER_LIMIT - 1,
-            Video::DURATION_LOWER_LIMIT,
-            Video::DURATION_UPPER_LIMIT,
-            Video::DURATION_UPPER_LIMIT + 1,
+            VideoInterface::DURATION_LOWER_LIMIT - 1,
+            VideoInterface::DURATION_LOWER_LIMIT,
+            VideoInterface::DURATION_UPPER_LIMIT,
+            VideoInterface::DURATION_UPPER_LIMIT + 1,
         ];
 
         foreach ($invalidValues as $duration) {
@@ -275,8 +252,8 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             $this->getPlayerLocationMock(),
             $this->getGalleryLocationMock(),
             $faker->numberBetween(
-                Video::DURATION_LOWER_LIMIT,
-                Video::DURATION_UPPER_LIMIT
+                VideoInterface::DURATION_LOWER_LIMIT,
+                VideoInterface::DURATION_UPPER_LIMIT
             ),
             $faker->dateTime,
             $faker->dateTime,
@@ -291,8 +268,8 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     {
         $invalidValues = [
             'foo',
-            Video::RATING_MIN - 0.1,
-            Video::RATING_MAX + 0.1,
+            VideoInterface::RATING_MIN - 0.1,
+            VideoInterface::RATING_MAX + 0.1,
         ];
 
         foreach ($invalidValues as $rating) {
@@ -321,8 +298,8 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             $this->getPlayerLocationMock(),
             $this->getGalleryLocationMock(),
             $faker->numberBetween(
-                Video::DURATION_LOWER_LIMIT,
-                Video::DURATION_UPPER_LIMIT
+                VideoInterface::DURATION_LOWER_LIMIT,
+                VideoInterface::DURATION_UPPER_LIMIT
             ),
             $faker->dateTime,
             $faker->dateTime,
@@ -367,8 +344,8 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             $this->getPlayerLocationMock(),
             $this->getGalleryLocationMock(),
             $faker->numberBetween(
-                Video::DURATION_LOWER_LIMIT,
-                Video::DURATION_UPPER_LIMIT
+                VideoInterface::DURATION_LOWER_LIMIT,
+                VideoInterface::DURATION_UPPER_LIMIT
             ),
             $faker->dateTime,
             $faker->dateTime,
@@ -414,14 +391,14 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             $this->getPlayerLocationMock(),
             $this->getGalleryLocationMock(),
             $faker->numberBetween(
-                Video::DURATION_LOWER_LIMIT,
-                Video::DURATION_UPPER_LIMIT
+                VideoInterface::DURATION_LOWER_LIMIT,
+                VideoInterface::DURATION_UPPER_LIMIT
             ),
             $faker->dateTime,
             $faker->dateTime,
             $faker->randomFloat(1, 0, 5),
             $faker->randomNumber(),
-            Video::FAMILY_FRIENDLY_NO,
+            VideoInterface::FAMILY_FRIENDLY_NO,
             $faker->word,
             $this->getRestrictionMock(),
             $requiresSubscription
@@ -478,7 +455,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             $faker->url
         );
 
-        for ($i = 0; $i < Video::TAG_MAX_COUNT; ++$i) {
+        for ($i = 0; $i < VideoInterface::TAG_MAX_COUNT; ++$i) {
             $video->addTag($this->getTagMock());
         }
 
@@ -491,7 +468,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
 
         $faker = $this->getFaker();
 
-        $category = str_repeat('a', Video::CATEGORY_MAX_LENGTH + 1);
+        $category = str_repeat('a', VideoInterface::CATEGORY_MAX_LENGTH + 1);
 
         new Video(
             $faker->url,
@@ -501,14 +478,14 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             $this->getPlayerLocationMock(),
             $this->getGalleryLocationMock(),
             $faker->numberBetween(
-                Video::DURATION_LOWER_LIMIT,
-                Video::DURATION_UPPER_LIMIT
+                VideoInterface::DURATION_LOWER_LIMIT,
+                VideoInterface::DURATION_UPPER_LIMIT
             ),
             $faker->dateTime,
             $faker->dateTime,
             $faker->randomFloat(1, 0, 5),
             $faker->randomNumber(),
-            Video::FAMILY_FRIENDLY_NO,
+            VideoInterface::FAMILY_FRIENDLY_NO,
             $category
         );
     }
@@ -552,19 +529,19 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             $this->getPlayerLocationMock(),
             $this->getGalleryLocationMock(),
             $faker->numberBetween(
-                Video::DURATION_LOWER_LIMIT,
-                Video::DURATION_UPPER_LIMIT
+                VideoInterface::DURATION_LOWER_LIMIT,
+                VideoInterface::DURATION_UPPER_LIMIT
             ),
             $faker->dateTime,
             $faker->dateTime,
             $faker->randomFloat(1, 0, 5),
             $faker->randomNumber(),
-            Video::FAMILY_FRIENDLY_NO,
+            VideoInterface::FAMILY_FRIENDLY_NO,
             $faker->word,
             $this->getRestrictionMock(),
             $faker->randomElement([
-                Video::REQUIRES_SUBSCRIPTION_YES,
-                Video::REQUIRES_SUBSCRIPTION_NO,
+                VideoInterface::REQUIRES_SUBSCRIPTION_YES,
+                VideoInterface::REQUIRES_SUBSCRIPTION_NO,
             ]),
             $this->getUploaderMock(),
             $this->getPlatformMock(),

--- a/test/Writer/News/NewsWriterTest.php
+++ b/test/Writer/News/NewsWriterTest.php
@@ -9,7 +9,6 @@
 namespace Refinery29\Sitemap\Test\Writer\News;
 
 use DateTime;
-use Refinery29\Sitemap\Component\News\News;
 use Refinery29\Sitemap\Component\News\NewsInterface;
 use Refinery29\Sitemap\Component\News\PublicationInterface;
 use Refinery29\Sitemap\Test\Writer\AbstractTestCase;
@@ -71,10 +70,10 @@ class NewsWriterTest extends AbstractTestCase
         $publication = $this->getPublicationMock();
         $publicationDate = $faker->dateTime;
         $title = $faker->sentence;
-        $access = News::ACCESS_SUBSCRIPTION;
+        $access = NewsInterface::ACCESS_SUBSCRIPTION;
         $genres = $faker->randomElements([
-            News::GENRE_SATIRE,
-            News::GENRE_OPINION,
+            NewsInterface::GENRE_SATIRE,
+            NewsInterface::GENRE_OPINION,
         ]);
         $keywords = $faker->words;
         $stockTickers = $faker->words;

--- a/test/Writer/UrlSetWriterTest.php
+++ b/test/Writer/UrlSetWriterTest.php
@@ -8,12 +8,11 @@
  */
 namespace Refinery29\Sitemap\Test\Writer;
 
-use Refinery29\Sitemap\Component\Image\Image;
-use Refinery29\Sitemap\Component\News\News;
+use Refinery29\Sitemap\Component\Image\ImageInterface;
+use Refinery29\Sitemap\Component\News\NewsInterface;
 use Refinery29\Sitemap\Component\UrlInterface;
-use Refinery29\Sitemap\Component\UrlSet;
 use Refinery29\Sitemap\Component\UrlSetInterface;
-use Refinery29\Sitemap\Component\Video\Video;
+use Refinery29\Sitemap\Component\Video\VideoInterface;
 use Refinery29\Sitemap\Writer\UrlSetWriter;
 use Refinery29\Sitemap\Writer\UrlWriter;
 use XMLWriter;
@@ -41,10 +40,10 @@ class UrlSetWriterTest extends AbstractTestCase
 
         $this->expectToStartElement($xmlWriter, 'urlset');
 
-        $this->expectToWriteAttribute($xmlWriter, UrlSet::XML_NAMESPACE_ATTRIBUTE, UrlSet::XML_NAMESPACE_URI);
-        $this->expectToWriteAttribute($xmlWriter, Image::XML_NAMESPACE_ATTRIBUTE, Image::XML_NAMESPACE_URI);
-        $this->expectToWriteAttribute($xmlWriter, News::XML_NAMESPACE_ATTRIBUTE, News::XML_NAMESPACE_URI);
-        $this->expectToWriteAttribute($xmlWriter, Video::XML_NAMESPACE_ATTRIBUTE, Video::XML_NAMESPACE_URI);
+        $this->expectToWriteAttribute($xmlWriter, UrlSetInterface::XML_NAMESPACE_ATTRIBUTE, UrlSetInterface::XML_NAMESPACE_URI);
+        $this->expectToWriteAttribute($xmlWriter, ImageInterface::XML_NAMESPACE_ATTRIBUTE, ImageInterface::XML_NAMESPACE_URI);
+        $this->expectToWriteAttribute($xmlWriter, NewsInterface::XML_NAMESPACE_ATTRIBUTE, NewsInterface::XML_NAMESPACE_URI);
+        $this->expectToWriteAttribute($xmlWriter, VideoInterface::XML_NAMESPACE_ATTRIBUTE, VideoInterface::XML_NAMESPACE_URI);
 
         $urlWriter = $this->getUrlWriterMock();
 

--- a/test/Writer/UrlWriterTest.php
+++ b/test/Writer/UrlWriterTest.php
@@ -11,7 +11,6 @@ namespace Refinery29\Sitemap\Test\Writer;
 use DateTime;
 use Refinery29\Sitemap\Component\Image\ImageInterface;
 use Refinery29\Sitemap\Component\News\NewsInterface;
-use Refinery29\Sitemap\Component\Url;
 use Refinery29\Sitemap\Component\UrlInterface;
 use Refinery29\Sitemap\Component\Video\VideoInterface;
 use Refinery29\Sitemap\Writer\Image\ImageWriter;
@@ -54,13 +53,13 @@ class UrlWriterTest extends AbstractTestCase
         $location = $faker->url;
         $lastModified = $faker->dateTime;
         $changeFrequency = $faker->randomElement([
-            Url::CHANGE_FREQUENCY_ALWAYS,
-            Url::CHANGE_FREQUENCY_DAILY,
-            Url::CHANGE_FREQUENCY_HOURLY,
-            Url::CHANGE_FREQUENCY_MONTHLY,
-            Url::CHANGE_FREQUENCY_NEVER,
-            Url::CHANGE_FREQUENCY_WEEKLY,
-            Url::CHANGE_FREQUENCY_YEARLY,
+            UrlInterface::CHANGE_FREQUENCY_ALWAYS,
+            UrlInterface::CHANGE_FREQUENCY_DAILY,
+            UrlInterface::CHANGE_FREQUENCY_HOURLY,
+            UrlInterface::CHANGE_FREQUENCY_MONTHLY,
+            UrlInterface::CHANGE_FREQUENCY_NEVER,
+            UrlInterface::CHANGE_FREQUENCY_WEEKLY,
+            UrlInterface::CHANGE_FREQUENCY_YEARLY,
         ]);
         $priority = $faker->randomFloat(2, 0, 1);
         $images = [

--- a/test/Writer/Video/PlatformWriterTest.php
+++ b/test/Writer/Video/PlatformWriterTest.php
@@ -8,7 +8,6 @@
  */
 namespace Refinery29\Sitemap\Test\Writer\Video;
 
-use Refinery29\Sitemap\Component\Video\Platform;
 use Refinery29\Sitemap\Component\Video\PlatformInterface;
 use Refinery29\Sitemap\Test\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\Video\PlatformWriter;
@@ -21,14 +20,14 @@ class PlatformWriterTest extends AbstractTestCase
         $faker = $this->getFaker();
 
         $relationship = $faker->randomElement([
-            Platform::RELATIONSHIP_ALLOW,
-            Platform::RELATIONSHIP_DENY,
+            PlatformInterface::RELATIONSHIP_ALLOW,
+            PlatformInterface::RELATIONSHIP_DENY,
         ]);
 
         $types = $faker->randomElements([
-            Platform::TYPE_MOBILE,
-            Platform::TYPE_TV,
-            Platform::TYPE_WEB,
+            PlatformInterface::TYPE_MOBILE,
+            PlatformInterface::TYPE_TV,
+            PlatformInterface::TYPE_WEB,
         ], 2);
 
         $platform = $this->getPlatformMock(

--- a/test/Writer/Video/RestrictionWriterTest.php
+++ b/test/Writer/Video/RestrictionWriterTest.php
@@ -8,7 +8,6 @@
  */
 namespace Refinery29\Sitemap\Test\Writer\Video;
 
-use Refinery29\Sitemap\Component\Video\Restriction;
 use Refinery29\Sitemap\Component\Video\RestrictionInterface;
 use Refinery29\Sitemap\Test\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\Video\RestrictionWriter;
@@ -21,8 +20,8 @@ class RestrictionWriterTest extends AbstractTestCase
         $faker = $this->getFaker();
 
         $relationship = $faker->randomElement([
-            Restriction::RELATIONSHIP_ALLOW,
-            Restriction::RELATIONSHIP_DENY,
+            RestrictionInterface::RELATIONSHIP_ALLOW,
+            RestrictionInterface::RELATIONSHIP_DENY,
         ]);
 
         $countryCodes = [

--- a/test/Writer/Video/VideoWriterTest.php
+++ b/test/Writer/Video/VideoWriterTest.php
@@ -16,7 +16,6 @@ use Refinery29\Sitemap\Component\Video\PriceInterface;
 use Refinery29\Sitemap\Component\Video\RestrictionInterface;
 use Refinery29\Sitemap\Component\Video\TagInterface;
 use Refinery29\Sitemap\Component\Video\UploaderInterface;
-use Refinery29\Sitemap\Component\Video\Video;
 use Refinery29\Sitemap\Component\Video\VideoInterface;
 use Refinery29\Sitemap\Test\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\Video\GalleryLocationWriter;
@@ -92,25 +91,25 @@ class VideoWriterTest extends AbstractTestCase
         $playerLocation = $this->getPlayerLocationMock();
         $galleryLocation = $this->getGalleryLocationMock();
         $duration = $faker->numberBetween(
-            Video::DURATION_LOWER_LIMIT,
-            Video::DURATION_UPPER_LIMIT
+            VideoInterface::DURATION_LOWER_LIMIT,
+            VideoInterface::DURATION_UPPER_LIMIT
         );
         $publicationDate = $faker->dateTime;
         $expirationDate = $faker->dateTime;
         $rating = $faker->randomFloat(1, 0, 5);
         $viewCount = $faker->randomNumber();
-        $familyFriendly = Video::FAMILY_FRIENDLY_NO;
+        $familyFriendly = VideoInterface::FAMILY_FRIENDLY_NO;
         $category = $faker->word;
         $restriction = $this->getRestrictionMock();
         $requiresSubscription = $faker->randomElement([
-            Video::REQUIRES_SUBSCRIPTION_YES,
-            Video::REQUIRES_SUBSCRIPTION_NO,
+            VideoInterface::REQUIRES_SUBSCRIPTION_YES,
+            VideoInterface::REQUIRES_SUBSCRIPTION_NO,
         ]);
         $uploader = $this->getUploaderMock();
         $platform = $this->getPlatformMock();
         $live = $faker->randomElement([
-            Video::LIVE_NO,
-            Video::LIVE_YES,
+            VideoInterface::LIVE_NO,
+            VideoInterface::LIVE_YES,
         ]);
         $prices = [
             $this->getPriceMock(),


### PR DESCRIPTION
This PR

* [x] actually uses the constants as defined in the interfaces *everywhere*  

Follows #25.
