### PR TITLE
Fix: No need to disable constructor

### DIFF
--- a/test/Component/SitemapIndexTest.php
+++ b/test/Component/SitemapIndexTest.php
@@ -58,10 +58,7 @@ class SitemapIndexTest extends \PHPUnit_Framework_TestCase
      */
     private function getSitemapMock($location = null)
     {
-        $sitemap = $this->getMockBuilder(SitemapInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
+        $sitemap = $this->getMockBuilder(SitemapInterface::class)->getMock();
 
         $sitemap
             ->expects($this->any())


### PR DESCRIPTION
This PR

* [ ] does not disable a constructor when building a mock, as interfaces don't have constructors 

