### PR TITLE
Fix: Add arguments to docblock

### DIFF
--- a/test/Writer/Video/VideoWriterTest.php
+++ b/test/Writer/Video/VideoWriterTest.php
@@ -490,6 +490,9 @@ class VideoWriterTest extends AbstractTestCase
     }
 
     /**
+     * @param XMLWriter        $xmlWriter
+     * @param PriceInterface[] $prices
+     *
      * @return \PHPUnit_Framework_MockObject_MockObject|PriceWriter
      */
     private function getPriceWriterSpy(XMLWriter $xmlWriter, array $prices)


### PR DESCRIPTION
This PR

* [x] adds arguments to a docblock  
