### PR TITLE
Fix: Use more specific names for tests

### DIFF
--- a/test/Component/Image/ImageTest.php
+++ b/test/Component/Image/ImageTest.php
@@ -24,7 +24,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->isFinal());
     }
 
-    public function testImplementsInterface()
+    public function testImplementsImageInterface()
     {
         $location = $this->getFaker()->url;
 

--- a/test/Component/News/NewsTest.php
+++ b/test/Component/News/NewsTest.php
@@ -26,7 +26,7 @@ class NewsTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->isFinal());
     }
 
-    public function testImplementsInterface()
+    public function testImplementsNewsInterface()
     {
         $faker = $this->getFaker();
 

--- a/test/Component/News/PublicationTest.php
+++ b/test/Component/News/PublicationTest.php
@@ -24,7 +24,7 @@ class PublicationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->isFinal());
     }
 
-    public function testImplementsInterface()
+    public function testImplementsPublicationInterface()
     {
         $faker = $this->getFaker();
 

--- a/test/Component/SitemapTest.php
+++ b/test/Component/SitemapTest.php
@@ -24,7 +24,7 @@ class SitemapTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->isFinal());
     }
 
-    public function testImplementsInterface()
+    public function testImplementsSitemapInterface()
     {
         $sitemap = new Sitemap($this->getFaker()->url);
 

--- a/test/Component/Video/GalleryLocationTest.php
+++ b/test/Component/Video/GalleryLocationTest.php
@@ -24,7 +24,7 @@ class GalleryLocationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->isFinal());
     }
 
-    public function testImplementsInterface()
+    public function testImplementsGalleryLocationInterface()
     {
         $galleryLocation = new GalleryLocation($this->getFaker()->url);
 

--- a/test/Component/Video/PlatformTest.php
+++ b/test/Component/Video/PlatformTest.php
@@ -26,7 +26,7 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->isFinal());
     }
 
-    public function testImplementsInterface()
+    public function testImplementsPlatformInterface()
     {
         $faker = $this->getFaker();
 

--- a/test/Component/Video/PlayerLocationTest.php
+++ b/test/Component/Video/PlayerLocationTest.php
@@ -31,7 +31,7 @@ class PlayerLocationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->isFinal());
     }
 
-    public function testImplementsInterface()
+    public function testImplementsPlayerLocationInterface()
     {
         $playerLocation = new PlayerLocation($this->getFaker()->url);
 

--- a/test/Component/Video/PriceTest.php
+++ b/test/Component/Video/PriceTest.php
@@ -34,7 +34,7 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->isFinal());
     }
 
-    public function testImplementsInterface()
+    public function testImplementsPriceInterface()
     {
         $faker = $this->getFaker();
 

--- a/test/Component/Video/RestrictionTest.php
+++ b/test/Component/Video/RestrictionTest.php
@@ -25,7 +25,7 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->isFinal());
     }
 
-    public function testImplementsInterface()
+    public function testImplementsRestrictionInterface()
     {
         $restriction = new Restriction($this->getFaker()->randomElement([
             RestrictionInterface::RELATIONSHIP_ALLOW,

--- a/test/Component/Video/TagTest.php
+++ b/test/Component/Video/TagTest.php
@@ -24,7 +24,7 @@ class TagTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->isFinal());
     }
 
-    public function testImplementsInterface()
+    public function testImplementsTagInterface()
     {
         $tag = new Tag($this->getFaker()->word);
 

--- a/test/Component/Video/UploaderTest.php
+++ b/test/Component/Video/UploaderTest.php
@@ -24,7 +24,7 @@ class UploaderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->isFinal());
     }
 
-    public function testImplementsInterface()
+    public function testImplementsUploaderInterface()
     {
         $uploader = new Uploader($this->getFaker()->name);
 

--- a/test/Component/Video/VideoTest.php
+++ b/test/Component/Video/VideoTest.php
@@ -33,7 +33,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->isFinal());
     }
 
-    public function testImplementsInterface()
+    public function testImplementsVideoInterface()
     {
         $faker = $this->getFaker();
 


### PR DESCRIPTION
This PR

* [x] uses more specific names for tests asserting that specific interfaces are implemented
