### PR TITLE
Fix: Use reflection to assert that interfaces are implemented

### DIFF
--- a/test/Component/Image/ImageTest.php
+++ b/test/Component/Image/ImageTest.php
@@ -26,11 +26,9 @@ class ImageTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsImageInterface()
     {
-        $location = $this->getFaker()->url;
+        $reflectionClass = new ReflectionClass(Image::class);
 
-        $image = new Image($location);
-
-        $this->assertInstanceOf(ImageInterface::class, $image);
+        $this->assertTrue($reflectionClass->implementsInterface(ImageInterface::class));
     }
 
     public function testConstructorSetsValues()

--- a/test/Component/News/NewsTest.php
+++ b/test/Component/News/NewsTest.php
@@ -28,15 +28,9 @@ class NewsTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsNewsInterface()
     {
-        $faker = $this->getFaker();
+        $reflectionClass = new ReflectionClass(News::class);
 
-        $news = new News(
-            $this->getPublicationMock(),
-            $faker->dateTime,
-            $faker->sentence
-        );
-
-        $this->assertInstanceOf(NewsInterface::class, $news);
+        $this->assertTrue($reflectionClass->implementsInterface(NewsInterface::class));
     }
 
     public function testConstructorSetsValues()

--- a/test/Component/News/PublicationTest.php
+++ b/test/Component/News/PublicationTest.php
@@ -26,14 +26,9 @@ class PublicationTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsPublicationInterface()
     {
-        $faker = $this->getFaker();
+        $reflectionClass = new ReflectionClass(Publication::class);
 
-        $publication = new Publication(
-            $faker->name,
-            $faker->languageCode
-        );
-
-        $this->assertInstanceOf(PublicationInterface::class, $publication);
+        $this->assertTrue($reflectionClass->implementsInterface(PublicationInterface::class));
     }
 
     public function testConstructorSetsValues()

--- a/test/Component/SitemapTest.php
+++ b/test/Component/SitemapTest.php
@@ -26,9 +26,9 @@ class SitemapTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsSitemapInterface()
     {
-        $sitemap = new Sitemap($this->getFaker()->url);
+        $reflectionClass = new ReflectionClass(Sitemap::class);
 
-        $this->assertInstanceOf(SitemapInterface::class, $sitemap);
+        $this->assertTrue($reflectionClass->implementsInterface(SitemapInterface::class));
     }
 
     public function testConstructorSetsValues()

--- a/test/Component/Video/GalleryLocationTest.php
+++ b/test/Component/Video/GalleryLocationTest.php
@@ -26,9 +26,9 @@ class GalleryLocationTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsGalleryLocationInterface()
     {
-        $galleryLocation = new GalleryLocation($this->getFaker()->url);
+        $reflectionClass = new ReflectionClass(GalleryLocation::class);
 
-        $this->assertInstanceOf(GalleryLocationInterface::class, $galleryLocation);
+        $this->assertTrue($reflectionClass->implementsInterface(GalleryLocationInterface::class));
     }
 
     public function testConstructorSetsValues()

--- a/test/Component/Video/PlatformTest.php
+++ b/test/Component/Video/PlatformTest.php
@@ -28,14 +28,9 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsPlatformInterface()
     {
-        $faker = $this->getFaker();
+        $reflectionClass = new ReflectionClass(Platform::class);
 
-        $platform = new Platform($faker->randomElement([
-            PlatformInterface::RELATIONSHIP_ALLOW,
-            PlatformInterface::RELATIONSHIP_DENY,
-        ]));
-
-        $this->assertInstanceOf(PlatformInterface::class, $platform);
+        $this->assertTrue($reflectionClass->implementsInterface(PlatformInterface::class));
     }
 
     public function testConstructorSetsValues()

--- a/test/Component/Video/PlayerLocationTest.php
+++ b/test/Component/Video/PlayerLocationTest.php
@@ -33,9 +33,9 @@ class PlayerLocationTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsPlayerLocationInterface()
     {
-        $playerLocation = new PlayerLocation($this->getFaker()->url);
+        $reflectionClass = new ReflectionClass(PlayerLocation::class);
 
-        $this->assertInstanceOf(PlayerLocationInterface::class, $playerLocation);
+        $this->assertTrue($reflectionClass->implementsInterface(PlayerLocationInterface::class));
     }
 
     public function testConstructorSetsValues()

--- a/test/Component/Video/PriceTest.php
+++ b/test/Component/Video/PriceTest.php
@@ -36,14 +36,9 @@ class PriceTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsPriceInterface()
     {
-        $faker = $this->getFaker();
+        $reflectionClass = new ReflectionClass(Price::class);
 
-        $price = new Price(
-            $faker->randomFloat(2, 0.01),
-            $faker->currencyCode
-        );
-
-        $this->assertInstanceOf(PriceInterface::class, $price);
+        $this->assertTrue($reflectionClass->implementsInterface(PriceInterface::class));
     }
 
     public function testConstructorSetsValues()

--- a/test/Component/Video/RestrictionTest.php
+++ b/test/Component/Video/RestrictionTest.php
@@ -27,12 +27,9 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsRestrictionInterface()
     {
-        $restriction = new Restriction($this->getFaker()->randomElement([
-            RestrictionInterface::RELATIONSHIP_ALLOW,
-            RestrictionInterface::RELATIONSHIP_DENY,
-        ]));
+        $reflectionClass = new ReflectionClass(Restriction::class);
 
-        $this->assertInstanceOf(RestrictionInterface::class, $restriction);
+        $this->assertTrue($reflectionClass->implementsInterface(RestrictionInterface::class));
     }
 
     public function testConstructorSetsValues()

--- a/test/Component/Video/TagTest.php
+++ b/test/Component/Video/TagTest.php
@@ -26,9 +26,9 @@ class TagTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsTagInterface()
     {
-        $tag = new Tag($this->getFaker()->word);
+        $reflectionClass = new ReflectionClass(Tag::class);
 
-        $this->assertInstanceOf(TagInterface::class, $tag);
+        $this->assertTrue($reflectionClass->implementsInterface(TagInterface::class));
     }
 
     public function testConstructorSetsValues()

--- a/test/Component/Video/UploaderTest.php
+++ b/test/Component/Video/UploaderTest.php
@@ -26,9 +26,9 @@ class UploaderTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsUploaderInterface()
     {
-        $uploader = new Uploader($this->getFaker()->name);
+        $reflectionClass = new ReflectionClass(Uploader::class);
 
-        $this->assertInstanceOf(UploaderInterface::class, $uploader);
+        $this->assertTrue($reflectionClass->implementsInterface(UploaderInterface::class));
     }
 
     public function testConstructorSetsValues()

--- a/test/Component/Video/VideoTest.php
+++ b/test/Component/Video/VideoTest.php
@@ -35,16 +35,9 @@ class VideoTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsVideoInterface()
     {
-        $faker = $this->getFaker();
+        $reflectionClass = new ReflectionClass(Video::class);
 
-        $video = new Video(
-            $faker->url,
-            $faker->sentence,
-            $faker->paragraphs(5, true),
-            $faker->url
-        );
-
-        $this->assertInstanceOf(VideoInterface::class, $video);
+        $this->assertTrue($reflectionClass->implementsInterface(VideoInterface::class));
     }
 
     public function testConstructorSetsValues()


### PR DESCRIPTION
This PR

* [x] uses reflection to assert that interfaces are implemented
