### PR TITLE
Fix: Throw InvalidArgumentException

### DIFF
--- a/src/Component/SitemapIndex.php
+++ b/src/Component/SitemapIndex.php
@@ -18,7 +18,7 @@ final class SitemapIndex implements SitemapIndexInterface
     public function addSitemap(SitemapInterface $sitemap)
     {
         if ($this->hasSitemapWithLocation($sitemap->getLocation())) {
-            throw new \BadMethodCallException(sprintf(
+            throw new \InvalidArgumentException(sprintf(
                 'Can not add sitemap with duplicate location "%s"',
                 $sitemap->getLocation()
             ));

--- a/src/Component/Url.php
+++ b/src/Component/Url.php
@@ -8,8 +8,8 @@
  */
 namespace Refinery29\Sitemap\Component;
 
-use BadMethodCallException;
 use DateTime;
+use InvalidArgumentException;
 use Refinery29\Sitemap\Component\Image\ImageInterface;
 use Refinery29\Sitemap\Component\News\NewsInterface;
 use Refinery29\Sitemap\Component\Video\VideoInterface;
@@ -95,7 +95,7 @@ final class Url implements UrlInterface
     public function addImage(ImageInterface $image)
     {
         if (count($this->images) === UrlInterface::IMAGE_MAX_COUNT) {
-            throw new BadMethodCallException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'Can not add more than %s images',
                 UrlInterface::IMAGE_MAX_COUNT
             ));

--- a/src/Component/Video/Platform.php
+++ b/src/Component/Video/Platform.php
@@ -8,7 +8,6 @@
  */
 namespace Refinery29\Sitemap\Component\Video;
 
-use BadMethodCallException;
 use InvalidArgumentException;
 
 final class Platform implements PlatformInterface
@@ -77,7 +76,7 @@ final class Platform implements PlatformInterface
         }
 
         if (in_array($type, $this->types)) {
-            throw new BadMethodCallException('Can not add the same type twice');
+            throw new InvalidArgumentException('Can not add the same type twice');
         }
 
         $this->types[] = $type;

--- a/src/Component/Video/Video.php
+++ b/src/Component/Video/Video.php
@@ -8,7 +8,6 @@
  */
 namespace Refinery29\Sitemap\Component\Video;
 
-use BadMethodCallException;
 use DateTime;
 use InvalidArgumentException;
 
@@ -381,7 +380,7 @@ final class Video implements VideoInterface
     public function addTag(TagInterface $tag)
     {
         if (count($this->tags) === VideoInterface::TAG_MAX_COUNT) {
-            throw new BadMethodCallException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'Can not add more than %s tags',
                 VideoInterface::TAG_MAX_COUNT
             ));

--- a/test/Component/SitemapIndexTest.php
+++ b/test/Component/SitemapIndexTest.php
@@ -8,6 +8,7 @@
  */
 namespace Refinery29\Sitemap\Test\Component;
 
+use InvalidArgumentException;
 use Refinery29\Sitemap\Component\SitemapIndex;
 use Refinery29\Sitemap\Component\SitemapInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
@@ -46,7 +47,7 @@ class SitemapIndexTest extends \PHPUnit_Framework_TestCase
 
     public function testCanNotAddTwoSitemapsWithSameLocation()
     {
-        $this->setExpectedException(\BadMethodCallException::class);
+        $this->setExpectedException(InvalidArgumentException::class);
 
         $location = $this->getFaker()->url;
 

--- a/test/Component/UrlTest.php
+++ b/test/Component/UrlTest.php
@@ -8,7 +8,7 @@
  */
 namespace Refinery29\Sitemap\Test\Component;
 
-use BadMethodCallException;
+use InvalidArgumentException;
 use Refinery29\Sitemap\Component\Image\ImageInterface;
 use Refinery29\Sitemap\Component\News\NewsInterface;
 use Refinery29\Sitemap\Component\Url;
@@ -83,7 +83,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     public function testCanNotAddMoreThanMaximumNumberOfImages()
     {
-        $this->setExpectedException(BadMethodCallException::class);
+        $this->setExpectedException(InvalidArgumentException::class);
 
         $url = new Url($this->getFaker()->url);
 

--- a/test/Component/Video/PlatformTest.php
+++ b/test/Component/Video/PlatformTest.php
@@ -8,7 +8,6 @@
  */
 namespace Refinery29\Sitemap\Test\Component\Video;
 
-use BadMethodCallException;
 use InvalidArgumentException;
 use Refinery29\Sitemap\Component\Video\Platform;
 use Refinery29\Sitemap\Component\Video\PlatformInterface;
@@ -91,7 +90,7 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
 
     public function testCanNotAddSameTypeTwice()
     {
-        $this->setExpectedException(BadMethodCallException::class);
+        $this->setExpectedException(InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 

--- a/test/Component/Video/VideoTest.php
+++ b/test/Component/Video/VideoTest.php
@@ -8,7 +8,6 @@
  */
 namespace Refinery29\Sitemap\Test\Component\Video;
 
-use BadMethodCallException;
 use InvalidArgumentException;
 use Refinery29\Sitemap\Component\Video\GalleryLocationInterface;
 use Refinery29\Sitemap\Component\Video\PlatformInterface;
@@ -445,7 +444,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
 
     public function testCanNotAddMoreThanMaximumNumberOfTags()
     {
-        $this->setExpectedException(BadMethodCallException::class);
+        $this->setExpectedException(InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 


### PR DESCRIPTION
This PR

* [x] throws `InvalidArgumentException`s instead of `BadMethodCallException`s  

Related to #27.
