### PR TITLE
Fix: Rename variable containing choices

### DIFF
--- a/src/Component/News/News.php
+++ b/src/Component/News/News.php
@@ -98,12 +98,12 @@ final class News implements NewsInterface
      */
     private function setAccess($access = null)
     {
-        $allowedValues = [
+        $choices = [
             NewsInterface::ACCESS_REGISTRATION,
             NewsInterface::ACCESS_SUBSCRIPTION,
         ];
 
-        Assertion::nullOrChoice($access, $allowedValues);
+        Assertion::nullOrChoice($access, $choices);
 
         $this->access = $access;
     }
@@ -118,7 +118,7 @@ final class News implements NewsInterface
      */
     private function setGenres(array $genres = [])
     {
-        $allowedValues = [
+        $choices = [
             NewsInterface::GENRE_BLOG,
             NewsInterface::GENRE_OP_ED,
             NewsInterface::GENRE_OPINION,
@@ -126,7 +126,7 @@ final class News implements NewsInterface
             NewsInterface::GENRE_USER_GENERATED,
         ];
 
-        Assertion::allChoice($genres, $allowedValues);
+        Assertion::allChoice($genres, $choices);
 
         $this->genres = $genres;
     }

--- a/src/Component/Video/Platform.php
+++ b/src/Component/Video/Platform.php
@@ -35,12 +35,12 @@ final class Platform implements PlatformInterface
      */
     private function setRelationship($relationship)
     {
-        $allowedValues = [
+        $choices = [
             PlatformInterface::RELATIONSHIP_ALLOW,
             PlatformInterface::RELATIONSHIP_DENY,
         ];
 
-        Assertion::choice($relationship, $allowedValues);
+        Assertion::choice($relationship, $choices);
 
         $this->relationship = $relationship;
     }
@@ -55,13 +55,13 @@ final class Platform implements PlatformInterface
      */
     public function addType($type)
     {
-        $allowedValues = [
+        $choices = [
             PlatformInterface::TYPE_MOBILE,
             PlatformInterface::TYPE_TV,
             PlatformInterface::TYPE_WEB,
         ];
 
-        Assertion::choice($type, $allowedValues);
+        Assertion::choice($type, $choices);
         Assertion::false(in_array($type, $this->types));
 
         $this->types[] = $type;

--- a/src/Component/Video/PlayerLocation.php
+++ b/src/Component/Video/PlayerLocation.php
@@ -51,12 +51,12 @@ final class PlayerLocation implements PlayerLocationInterface
      */
     private function setAllowEmbed($allowEmbed = null)
     {
-        $allowedValues = [
+        $choices = [
             PlayerLocationInterface::ALLOW_EMBED_NO,
             PlayerLocationInterface::ALLOW_EMBED_YES,
         ];
 
-        Assertion::nullOrChoice($allowEmbed, $allowedValues);
+        Assertion::nullOrChoice($allowEmbed, $choices);
 
         $this->allowEmbed = $allowEmbed;
     }

--- a/src/Component/Video/Price.php
+++ b/src/Component/Video/Price.php
@@ -73,12 +73,12 @@ final class Price implements PriceInterface
      */
     private function setType($type = null)
     {
-        $allowedValues = [
+        $choices = [
             PriceInterface::TYPE_OWN,
             PriceInterface::TYPE_RENT,
         ];
 
-        Assertion::nullOrChoice($type, $allowedValues);
+        Assertion::nullOrChoice($type, $choices);
 
         $this->type = $type;
     }
@@ -93,12 +93,12 @@ final class Price implements PriceInterface
      */
     private function setResolution($resolution = null)
     {
-        $allowedValues = [
+        $choices = [
             PriceInterface::RESOLUTION_HD,
             PriceInterface::RESOLUTION_SD,
         ];
 
-        Assertion::nullOrChoice($resolution, $allowedValues);
+        Assertion::nullOrChoice($resolution, $choices);
 
         $this->resolution = $resolution;
     }

--- a/src/Component/Video/Restriction.php
+++ b/src/Component/Video/Restriction.php
@@ -35,12 +35,12 @@ final class Restriction implements RestrictionInterface
      */
     private function setRelationship($relationship)
     {
-        $allowedValues = [
+        $choices = [
             RestrictionInterface::RELATIONSHIP_ALLOW,
             RestrictionInterface::RELATIONSHIP_DENY,
         ];
 
-        Assertion::choice($relationship, $allowedValues);
+        Assertion::choice($relationship, $choices);
 
         $this->relationship = $relationship;
     }

--- a/src/Component/Video/Video.php
+++ b/src/Component/Video/Video.php
@@ -393,12 +393,12 @@ final class Video implements VideoInterface
      */
     private function setRequiresSubscription($requiresSubscription = null)
     {
-        $allowedValues = [
+        $choices = [
             VideoInterface::REQUIRES_SUBSCRIPTION_NO,
             VideoInterface::REQUIRES_SUBSCRIPTION_YES,
         ];
 
-        Assertion::nullOrChoice($requiresSubscription, $allowedValues);
+        Assertion::nullOrChoice($requiresSubscription, $choices);
 
         $this->requiresSubscription = $requiresSubscription;
     }
@@ -423,12 +423,12 @@ final class Video implements VideoInterface
      */
     private function setLive($live = null)
     {
-        $allowedValues = [
+        $choices = [
             VideoInterface::LIVE_NO,
             VideoInterface::LIVE_YES,
         ];
 
-        Assertion::nullOrChoice($live, $allowedValues);
+        Assertion::nullOrChoice($live, $choices);
 
         $this->live = $live;
     }


### PR DESCRIPTION
This PR

* [x] renames variables containing choices  

Follows #27.