### PR TITLE
Enhancement: Add constant for maximum number of URLs

### DIFF
--- a/src/Component/UrlSetInterface.php
+++ b/src/Component/UrlSetInterface.php
@@ -20,6 +20,11 @@ interface UrlSetInterface
     const XML_NAMESPACE_URI = 'http://www.sitemaps.org/schemas/sitemap/0.9';
 
     /**
+     * Constant for the maximum number of URLs which can be added to a UrlSet
+     */
+    const URL_MAX_COUNT = 50000;
+
+    /**
      * @param UrlInterface $url
      */
     public function addUrl(UrlInterface $url);

--- a/test/Component/UrlSetInterfaceTest.php
+++ b/test/Component/UrlSetInterfaceTest.php
@@ -19,5 +19,7 @@ class UrlSetInterfaceTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertSame('xmlns', UrlSetInterface::XML_NAMESPACE_ATTRIBUTE);
         $this->assertSame('http://www.sitemaps.org/schemas/sitemap/0.9', UrlSetInterface::XML_NAMESPACE_URI);
+
+        $this->assertSame(50000, UrlSetInterface::URL_MAX_COUNT);
     }
 }


### PR DESCRIPTION
This PR

* [x] provides a constant for the maximum number of URLs that can be added to a sitemap  

:information_desk_person: For reference, see https://support.google.com/webmasters/answer/183668?hl=en:

> All formats limit a single sitemap to 10MB (uncompressed) and 50,000 URLs. If you have a larger file or more URLs, you will have to break your list into multiple sitemaps. You can optionally create a sitemap index file (a file that points to a list of sitemaps) and submit that single index file to Google. You can submit multiple sitemaps and/or sitemap index files to Google.
