### PR TITLE
Fix: Prevent adding more than 50,000 URLs to a UrlSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $url = new Component\Url(
 $urlSet->add($url);
 ```
 
-:bulb: Careful with adding too many URLs, Google imposes a limit to the number of URLs.
+:bulb: Google imposes a limit of 50,000 URLs that can be added to any sitemap..
  
 ### `Image`
 

--- a/src/Component/UrlSet.php
+++ b/src/Component/UrlSet.php
@@ -8,6 +8,8 @@
  */
 namespace Refinery29\Sitemap\Component;
 
+use Assert\Assertion;
+
 final class UrlSet implements UrlSetInterface
 {
     /**
@@ -17,6 +19,8 @@ final class UrlSet implements UrlSetInterface
 
     public function addUrl(UrlInterface $url)
     {
+        Assertion::lessThan(count($this->urls), UrlSetInterface::URL_MAX_COUNT);
+
         $this->urls[] = $url;
     }
 

--- a/test/Component/UrlSetTest.php
+++ b/test/Component/UrlSetTest.php
@@ -8,8 +8,10 @@
  */
 namespace Refinery29\Sitemap\Test\Component;
 
+use InvalidArgumentException;
 use Refinery29\Sitemap\Component\UrlInterface;
 use Refinery29\Sitemap\Component\UrlSet;
+use Refinery29\Sitemap\Component\UrlSetInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 use ReflectionClass;
 
@@ -42,6 +44,52 @@ class UrlSetTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $urlSet->getUrls());
         $this->assertCount(1, $urlSet->getUrls());
         $this->assertSame($url, $urlSet->getUrls()[0]);
+    }
+
+    public function testCanAddALotOfUrls()
+    {
+        $urls = array_fill(
+            0,
+            UrlSetInterface::URL_MAX_COUNT - 1,
+            $this->getUrlMock()
+        );
+
+        $urlSet = new UrlSet();
+
+        $reflectionProperty = new \ReflectionProperty(UrlSet::class, 'urls');
+
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($urlSet, $urls);
+
+        $url = $this->getUrlMock();
+
+        $urlSet->addUrl($url);
+
+        $this->assertInternalType('array', $urlSet->getUrls());
+        $this->assertCount(UrlSetInterface::URL_MAX_COUNT, $urlSet->getUrls());
+        $this->assertContains($url, $urlSet->getUrls());
+    }
+
+    public function testCanNotAddMoreUrlMaxCountUrls()
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $urls = array_fill(
+            0,
+            UrlSetInterface::URL_MAX_COUNT,
+            $this->getUrlMock()
+        );
+
+        $urlSet = new UrlSet();
+
+        $reflectionProperty = new \ReflectionProperty(UrlSet::class, 'urls');
+
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($urlSet, $urls);
+
+        $url = $this->getUrlMock();
+
+        $urlSet->addUrl($url);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] prevents adding more than 50,000 URLs to a `UrlSet`

Follows #36.