### PR TITLE
Fix: Use DateTimeInterface instead of DateTime

### DIFF
--- a/src/Component/News/News.php
+++ b/src/Component/News/News.php
@@ -9,7 +9,7 @@
 namespace Refinery29\Sitemap\Component\News;
 
 use Assert\Assertion;
-use DateTime;
+use DateTimeInterface;
 
 final class News implements NewsInterface
 {
@@ -19,7 +19,7 @@ final class News implements NewsInterface
     private $publication;
 
     /**
-     * @var DateTime
+     * @var DateTimeInterface
      */
     private $publicationDate;
 
@@ -50,7 +50,7 @@ final class News implements NewsInterface
 
     /**
      * @param PublicationInterface $publication
-     * @param DateTime             $publicationDate
+     * @param DateTimeInterface    $publicationDate
      * @param string               $title
      * @param string|null          $access
      * @param array                $genres
@@ -59,7 +59,7 @@ final class News implements NewsInterface
      */
     public function __construct(
         PublicationInterface $publication,
-        DateTime $publicationDate,
+        DateTimeInterface $publicationDate,
         $title,
         $access = null,
         array $genres = [],

--- a/src/Component/News/NewsInterface.php
+++ b/src/Component/News/NewsInterface.php
@@ -8,7 +8,7 @@
  */
 namespace Refinery29\Sitemap\Component\News;
 
-use DateTime;
+use DateTimeInterface;
 
 /**
  * @link https://support.google.com/news/publisher/answer/74288?hl=en#exampleentry
@@ -53,7 +53,7 @@ interface NewsInterface
     public function getPublication();
 
     /**
-     * @return DateTime
+     * @return DateTimeInterface
      */
     public function getPublicationDate();
 

--- a/src/Component/Sitemap.php
+++ b/src/Component/Sitemap.php
@@ -8,7 +8,7 @@
  */
 namespace Refinery29\Sitemap\Component;
 
-use DateTime;
+use DateTimeInterface;
 
 final class Sitemap implements SitemapInterface
 {
@@ -18,15 +18,15 @@ final class Sitemap implements SitemapInterface
     private $location;
 
     /**
-     * @var DateTime|null
+     * @var DateTimeInterface|null
      */
     private $lastModified;
 
     /**
-     * @param string        $location
-     * @param DateTime|null $lastModified
+     * @param string                 $location
+     * @param DateTimeInterface|null $lastModified
      */
-    public function __construct($location, DateTime $lastModified = null)
+    public function __construct($location, DateTimeInterface $lastModified = null)
     {
         $this->location = $location;
         $this->lastModified = $lastModified;

--- a/src/Component/SitemapInterface.php
+++ b/src/Component/SitemapInterface.php
@@ -8,7 +8,7 @@
  */
 namespace Refinery29\Sitemap\Component;
 
-use DateTime;
+use DateTimeInterface;
 
 /**
  * @link https://support.google.com/webmasters/answer/75712?rd=1
@@ -21,7 +21,7 @@ interface SitemapInterface
     public function getLocation();
 
     /**
-     * @return DateTime|null
+     * @return DateTimeInterface|null
      */
     public function getLastModified();
 }

--- a/src/Component/Url.php
+++ b/src/Component/Url.php
@@ -9,7 +9,7 @@
 namespace Refinery29\Sitemap\Component;
 
 use Assert\Assertion;
-use DateTime;
+use DateTimeInterface;
 use Refinery29\Sitemap\Component\Image\ImageInterface;
 use Refinery29\Sitemap\Component\News\NewsInterface;
 use Refinery29\Sitemap\Component\Video\VideoInterface;
@@ -52,12 +52,12 @@ final class Url implements UrlInterface
     private $videos = [];
 
     /**
-     * @param string        $location
-     * @param DateTime|null $lastModified
-     * @param string|null   $changeFrequency
-     * @param string|null   $priority
+     * @param string                 $location
+     * @param DateTimeInterface|null $lastModified
+     * @param string|null            $changeFrequency
+     * @param string|null            $priority
      */
-    public function __construct($location, DateTime $lastModified = null, $changeFrequency = null, $priority = null)
+    public function __construct($location, DateTimeInterface $lastModified = null, $changeFrequency = null, $priority = null)
     {
         $this->location = $location;
         $this->lastModified = $lastModified;

--- a/src/Component/UrlInterface.php
+++ b/src/Component/UrlInterface.php
@@ -8,7 +8,7 @@
  */
 namespace Refinery29\Sitemap\Component;
 
-use DateTime;
+use DateTimeInterface;
 
 /**
  * @link https://support.google.com/webmasters/answer/183668?hl=en
@@ -39,7 +39,7 @@ interface UrlInterface
     public function getLocation();
 
     /**
-     * @return DateTime|null
+     * @return DateTimeInterface|null
      */
     public function getLastModified();
 

--- a/src/Component/Video/Video.php
+++ b/src/Component/Video/Video.php
@@ -9,7 +9,7 @@
 namespace Refinery29\Sitemap\Component\Video;
 
 use Assert\Assertion;
-use DateTime;
+use DateTimeInterface;
 
 final class Video implements VideoInterface
 {
@@ -49,12 +49,12 @@ final class Video implements VideoInterface
     private $duration;
 
     /**
-     * @var DateTime|null
+     * @var DateTimeInterface|null
      */
     private $publicationDate;
 
     /**
-     * @var DateTime|null
+     * @var DateTimeInterface|null
      */
     private $expirationDate;
 
@@ -121,8 +121,8 @@ final class Video implements VideoInterface
      * @param PlayerLocationInterface|null  $playerLocation
      * @param GalleryLocationInterface|null $galleryLocation
      * @param int|null                      $duration
-     * @param DateTime|null                 $publicationDate
-     * @param DateTime|null                 $expirationDate
+     * @param DateTimeInterface|null        $publicationDate
+     * @param DateTimeInterface|null        $expirationDate
      * @param float|null                    $rating
      * @param int|null                      $viewCount
      * @param string|null                   $familyFriendly
@@ -141,8 +141,8 @@ final class Video implements VideoInterface
         PlayerLocationInterface $playerLocation = null,
         GalleryLocationInterface $galleryLocation = null,
         $duration = null,
-        DateTime $publicationDate = null,
-        DateTime $expirationDate = null,
+        DateTimeInterface $publicationDate = null,
+        DateTimeInterface $expirationDate = null,
         $rating = null,
         $viewCount = null,
         $familyFriendly = null,

--- a/src/Component/Video/VideoInterface.php
+++ b/src/Component/Video/VideoInterface.php
@@ -8,7 +8,7 @@
  */
 namespace Refinery29\Sitemap\Component\Video;
 
-use DateTime;
+use DateTimeInterface;
 
 /**
  * @link https://developers.google.com/webmasters/videosearch/sitemaps
@@ -124,12 +124,12 @@ interface VideoInterface
     public function getDuration();
 
     /**
-     * @return DateTime|null
+     * @return DateTimeInterface|null
      */
     public function getPublicationDate();
 
     /**
-     * @return DateTime|null
+     * @return DateTimeInterface|null
      */
     public function getExpirationDate();
 

--- a/src/Writer/News/NewsWriter.php
+++ b/src/Writer/News/NewsWriter.php
@@ -8,7 +8,7 @@
  */
 namespace Refinery29\Sitemap\Writer\News;
 
-use DateTime;
+use DateTimeInterface;
 use Refinery29\Sitemap\Component\News\NewsInterface;
 use XMLWriter;
 
@@ -50,7 +50,7 @@ class NewsWriter
         $xmlWriter->endElement();
     }
 
-    private function writePublicationDate(XMLWriter $xmlWriter, DateTime $publicationDate)
+    private function writePublicationDate(XMLWriter $xmlWriter, DateTimeInterface $publicationDate)
     {
         $xmlWriter->startElement('news:publication_date');
         $xmlWriter->text($publicationDate->format('c'));

--- a/src/Writer/SitemapWriter.php
+++ b/src/Writer/SitemapWriter.php
@@ -8,7 +8,7 @@
  */
 namespace Refinery29\Sitemap\Writer;
 
-use DateTime;
+use DateTimeInterface;
 use Refinery29\Sitemap\Component\SitemapInterface;
 use XMLWriter;
 
@@ -38,7 +38,7 @@ class SitemapWriter
         $xmlWriter->endElement();
     }
 
-    private function writeLastModified(XMLWriter $xmlWriter, DateTime $lastModified = null)
+    private function writeLastModified(XMLWriter $xmlWriter, DateTimeInterface $lastModified = null)
     {
         if ($lastModified === null) {
             return;

--- a/src/Writer/UrlWriter.php
+++ b/src/Writer/UrlWriter.php
@@ -8,7 +8,7 @@
  */
 namespace Refinery29\Sitemap\Writer;
 
-use DateTime;
+use DateTimeInterface;
 use Refinery29\Sitemap\Component\Image\ImageInterface;
 use Refinery29\Sitemap\Component\News\NewsInterface;
 use Refinery29\Sitemap\Component\UrlInterface;
@@ -79,7 +79,7 @@ class UrlWriter
         $xmlWriter->endElement();
     }
 
-    private function writeLastModified(XMLWriter $xmlWriter, DateTime $lastModified = null)
+    private function writeLastModified(XMLWriter $xmlWriter, DateTimeInterface $lastModified = null)
     {
         if ($lastModified === null) {
             return;

--- a/src/Writer/Video/VideoWriter.php
+++ b/src/Writer/Video/VideoWriter.php
@@ -8,7 +8,7 @@
  */
 namespace Refinery29\Sitemap\Writer\Video;
 
-use DateTime;
+use DateTimeInterface;
 use Refinery29\Sitemap\Component\Video\GalleryLocationInterface;
 use Refinery29\Sitemap\Component\Video\PlatformInterface;
 use Refinery29\Sitemap\Component\Video\PlayerLocationInterface;
@@ -183,7 +183,7 @@ class VideoWriter
         $xmlWriter->endElement();
     }
 
-    private function writePublicationDate(XMLWriter $xmlWriter, DateTime $publicationDate = null)
+    private function writePublicationDate(XMLWriter $xmlWriter, DateTimeInterface $publicationDate = null)
     {
         if ($publicationDate === null) {
             return;
@@ -194,7 +194,7 @@ class VideoWriter
         $xmlWriter->endElement();
     }
 
-    private function writeExpirationDate(XMLWriter $xmlWriter, DateTime $expirationDate = null)
+    private function writeExpirationDate(XMLWriter $xmlWriter, DateTimeInterface $expirationDate = null)
     {
         if ($expirationDate === null) {
             return;


### PR DESCRIPTION
This PR

* [x] uses `DateTimeInterface` instead of `DateTime` for type-hints, leaving it up to the consumer on which implementation they want to use  

:information_desk_person: Since we require PHP5.5, this is safe (and nice).