### PR TITLE
Fix: Do not export .github directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/.github            export-ignore
 /test               export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore


### PR DESCRIPTION
This PR

* [x] adds `.github` to `.gitattributes`

Follows #22.
