### PR TITLE
Fix: Remove useless docblocks

### DIFF
--- a/src/Component/Url.php
+++ b/src/Component/Url.php
@@ -89,9 +89,6 @@ final class Url implements UrlInterface
         return $this->priority;
     }
 
-    /**
-     * @param ImageInterface $image
-     */
     public function addImage(ImageInterface $image)
     {
         Assertion::lessThan(count($this->images), UrlInterface::IMAGE_MAX_COUNT);
@@ -104,9 +101,6 @@ final class Url implements UrlInterface
         return $this->images;
     }
 
-    /**
-     * @param NewsInterface $news
-     */
     public function addNews(NewsInterface $news)
     {
         $this->news[] = $news;
@@ -117,9 +111,6 @@ final class Url implements UrlInterface
         return $this->news;
     }
 
-    /**
-     * @param VideoInterface $video
-     */
     public function addVideo(VideoInterface $video)
     {
         $this->videos[] = $video;

--- a/src/Component/Video/Video.php
+++ b/src/Component/Video/Video.php
@@ -336,9 +336,6 @@ final class Video implements VideoInterface
         return $this->familyFriendly;
     }
 
-    /**
-     * @param TagInterface $tag
-     */
     public function addTag(TagInterface $tag)
     {
         Assertion::lessThan(count($this->tags), VideoInterface::TAG_MAX_COUNT);
@@ -375,9 +372,6 @@ final class Video implements VideoInterface
         return $this->restriction;
     }
 
-    /**
-     * @param PriceInterface $price
-     */
     public function addPrice(PriceInterface $price)
     {
         $this->prices[] = $price;

--- a/src/Writer/Image/ImageWriter.php
+++ b/src/Writer/Image/ImageWriter.php
@@ -16,10 +16,6 @@ use XMLWriter;
  */
 class ImageWriter
 {
-    /**
-     * @param XMLWriter      $xmlWriter
-     * @param ImageInterface $image
-     */
     public function write(XMLWriter $xmlWriter, ImageInterface $image)
     {
         $xmlWriter->startElement('image:image');

--- a/src/Writer/News/NewsWriter.php
+++ b/src/Writer/News/NewsWriter.php
@@ -22,18 +22,11 @@ class NewsWriter
      */
     private $publicationWriter;
 
-    /**
-     * @param PublicationWriter $publicationWriter
-     */
     public function __construct(PublicationWriter $publicationWriter = null)
     {
         $this->publicationWriter = $publicationWriter ?: new PublicationWriter();
     }
 
-    /**
-     * @param XMLWriter     $xmlWriter
-     * @param NewsInterface $news
-     */
     public function write(XMLWriter $xmlWriter, NewsInterface $news)
     {
         $xmlWriter->startElement('news:news');

--- a/src/Writer/News/PublicationWriter.php
+++ b/src/Writer/News/PublicationWriter.php
@@ -16,10 +16,6 @@ use XMLWriter;
  */
 class PublicationWriter
 {
-    /**
-     * @param XMLWriter            $xmlWriter
-     * @param PublicationInterface $publication
-     */
     public function write(XMLWriter $xmlWriter, PublicationInterface $publication)
     {
         $xmlWriter->startElement('news:publication');

--- a/src/Writer/SitemapIndexWriter.php
+++ b/src/Writer/SitemapIndexWriter.php
@@ -21,18 +21,11 @@ class SitemapIndexWriter
      */
     private $sitemapWriter;
 
-    /**
-     * @param SitemapWriter $sitemapWriter
-     */
     public function __construct(SitemapWriter $sitemapWriter = null)
     {
         $this->sitemapWriter = $sitemapWriter ?: new SitemapWriter();
     }
 
-    /**
-     * @param XMLWriter             $xmlWriter
-     * @param SitemapIndexInterface $sitemapIndex
-     */
     public function write(XMLWriter $xmlWriter, SitemapIndexInterface $sitemapIndex)
     {
         $xmlWriter->startElement('sitemapindex');

--- a/src/Writer/SitemapWriter.php
+++ b/src/Writer/SitemapWriter.php
@@ -17,10 +17,6 @@ use XMLWriter;
  */
 class SitemapWriter
 {
-    /**
-     * @param XMLWriter        $xmlWriter
-     * @param SitemapInterface $sitemap
-     */
     public function write(XMLWriter $xmlWriter, SitemapInterface $sitemap)
     {
         $xmlWriter->startElement('sitemap');

--- a/src/Writer/UrlSetWriter.php
+++ b/src/Writer/UrlSetWriter.php
@@ -25,18 +25,11 @@ class UrlSetWriter
      */
     private $urlWriter;
 
-    /**
-     * @param UrlWriter $urlWriter
-     */
     public function __construct(UrlWriter $urlWriter = null)
     {
         $this->urlWriter = $urlWriter ?: new UrlWriter();
     }
 
-    /**
-     * @param XMLWriter       $xmlWriter
-     * @param UrlSetInterface $urlSet
-     */
     public function write(XMLWriter $xmlWriter, UrlSetInterface $urlSet)
     {
         $xmlWriter->startElement('urlset');
@@ -47,9 +40,6 @@ class UrlSetWriter
         $xmlWriter->endElement();
     }
 
-    /**
-     * @param XMLWriter $xmlWriter
-     */
     private function writeNamespaceAttributes(XMLWriter $xmlWriter)
     {
         $xmlWriter->writeAttribute(UrlSetInterface::XML_NAMESPACE_ATTRIBUTE, UrlSetInterface::XML_NAMESPACE_URI);

--- a/src/Writer/UrlWriter.php
+++ b/src/Writer/UrlWriter.php
@@ -38,11 +38,6 @@ class UrlWriter
      */
     private $videoWriter;
 
-    /**
-     * @param ImageWriter $imageWriter
-     * @param NewsWriter  $newsWriter
-     * @param VideoWriter $videoWriter
-     */
     public function __construct(
         ImageWriter $imageWriter = null,
         NewsWriter $newsWriter = null,
@@ -53,10 +48,6 @@ class UrlWriter
         $this->videoWriter = $videoWriter ?: new VideoWriter();
     }
 
-    /**
-     * @param XMLWriter    $xmlWriter
-     * @param UrlInterface $url
-     */
     public function write(XMLWriter $xmlWriter, UrlInterface $url)
     {
         $xmlWriter->startElement('url');

--- a/src/Writer/Video/GalleryLocationWriter.php
+++ b/src/Writer/Video/GalleryLocationWriter.php
@@ -16,10 +16,6 @@ use XMLWriter;
  */
 class GalleryLocationWriter
 {
-    /**
-     * @param XMLWriter                $xmlWriter
-     * @param GalleryLocationInterface $galleryLocation
-     */
     public function write(XMLWriter $xmlWriter, GalleryLocationInterface $galleryLocation)
     {
         $xmlWriter->startElement('video:gallery_loc');

--- a/src/Writer/Video/PlatformWriter.php
+++ b/src/Writer/Video/PlatformWriter.php
@@ -16,10 +16,6 @@ use XMLWriter;
  */
 class PlatformWriter
 {
-    /**
-     * @param XMLWriter         $xmlWriter
-     * @param PlatformInterface $platform
-     */
     public function write(XMLWriter $xmlWriter, PlatformInterface $platform)
     {
         $xmlWriter->startElement('video:platform');

--- a/src/Writer/Video/PlayerLocationWriter.php
+++ b/src/Writer/Video/PlayerLocationWriter.php
@@ -16,10 +16,6 @@ use XMLWriter;
  */
 class PlayerLocationWriter
 {
-    /**
-     * @param XMLWriter               $xmlWriter
-     * @param PlayerLocationInterface $playerLocation
-     */
     public function write(XMLWriter $xmlWriter, PlayerLocationInterface $playerLocation)
     {
         $xmlWriter->startElement('video:player_loc');

--- a/src/Writer/Video/PriceWriter.php
+++ b/src/Writer/Video/PriceWriter.php
@@ -16,10 +16,6 @@ use XMLWriter;
  */
 class PriceWriter
 {
-    /**
-     * @param XMLWriter      $xmlWriter
-     * @param PriceInterface $price
-     */
     public function write(XMLWriter $xmlWriter, PriceInterface $price)
     {
         $xmlWriter->startElement('video:price');

--- a/src/Writer/Video/RestrictionWriter.php
+++ b/src/Writer/Video/RestrictionWriter.php
@@ -16,10 +16,6 @@ use XMLWriter;
  */
 class RestrictionWriter
 {
-    /**
-     * @param XMLWriter            $xmlWriter
-     * @param RestrictionInterface $restriction
-     */
     public function write(XMLWriter $xmlWriter, RestrictionInterface $restriction)
     {
         $xmlWriter->startElement('video:restriction');

--- a/src/Writer/Video/TagWriter.php
+++ b/src/Writer/Video/TagWriter.php
@@ -16,10 +16,6 @@ use XMLWriter;
  */
 class TagWriter
 {
-    /**
-     * @param XMLWriter    $xmlWriter
-     * @param TagInterface $tag
-     */
     public function write(XMLWriter $xmlWriter, TagInterface $tag)
     {
         $xmlWriter->startElement('video:tag');

--- a/src/Writer/Video/UploaderWriter.php
+++ b/src/Writer/Video/UploaderWriter.php
@@ -16,10 +16,6 @@ use XMLWriter;
  */
 class UploaderWriter
 {
-    /**
-     * @param XMLWriter         $xmlWriter
-     * @param UploaderInterface $uploader
-     */
     public function write(XMLWriter $xmlWriter, UploaderInterface $uploader)
     {
         $xmlWriter->startElement('video:uploader');

--- a/src/Writer/Video/VideoWriter.php
+++ b/src/Writer/Video/VideoWriter.php
@@ -59,15 +59,6 @@ class VideoWriter
      */
     private $tagWriter;
 
-    /**
-     * @param PlayerLocationWriter  $playerLocationWriter
-     * @param GalleryLocationWriter $galleryLocationWriter
-     * @param RestrictionWriter     $restrictionWriter
-     * @param UploaderWriter        $uploaderWriter
-     * @param PlatformWriter        $platformWriter
-     * @param PriceWriter           $priceWriter
-     * @param TagWriter             $tagWriter
-     */
     public function __construct(
         PlayerLocationWriter $playerLocationWriter = null,
         GalleryLocationWriter $galleryLocationWriter = null,
@@ -86,10 +77,6 @@ class VideoWriter
         $this->tagWriter = $tagWriter ?: new TagWriter();
     }
 
-    /**
-     * @param XMLWriter      $xmlWriter
-     * @param VideoInterface $video
-     */
     public function write(XMLWriter $xmlWriter, VideoInterface $video)
     {
         $xmlWriter->startElement('video:video');


### PR DESCRIPTION
This PR

* [x] removes docblocks where all arguments are sufficiently  type-hinted  

:information_desk_person: Having these docblocks has no benefits, only costs.