### PR TITLE
Fix: Flip arguments

### DIFF
--- a/src/Writer/Image/ImageWriter.php
+++ b/src/Writer/Image/ImageWriter.php
@@ -16,7 +16,7 @@ use XMLWriter;
  */
 class ImageWriter
 {
-    public function write(XMLWriter $xmlWriter, ImageInterface $image)
+    public function write(ImageInterface $image, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('image:image');
 

--- a/src/Writer/News/NewsWriter.php
+++ b/src/Writer/News/NewsWriter.php
@@ -27,11 +27,11 @@ class NewsWriter
         $this->publicationWriter = $publicationWriter ?: new PublicationWriter();
     }
 
-    public function write(XMLWriter $xmlWriter, NewsInterface $news)
+    public function write(NewsInterface $news, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('news:news');
 
-        $this->publicationWriter->write($xmlWriter, $news->getPublication());
+        $this->publicationWriter->write($news->getPublication(), $xmlWriter);
 
         $this->writePublicationDate($xmlWriter, $news->getPublicationDate());
         $this->writeTitle($xmlWriter, $news->getTitle());

--- a/src/Writer/News/PublicationWriter.php
+++ b/src/Writer/News/PublicationWriter.php
@@ -16,7 +16,7 @@ use XMLWriter;
  */
 class PublicationWriter
 {
-    public function write(XMLWriter $xmlWriter, PublicationInterface $publication)
+    public function write(PublicationInterface $publication, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('news:publication');
 

--- a/src/Writer/SitemapIndexWriter.php
+++ b/src/Writer/SitemapIndexWriter.php
@@ -26,13 +26,13 @@ class SitemapIndexWriter
         $this->sitemapWriter = $sitemapWriter ?: new SitemapWriter();
     }
 
-    public function write(XMLWriter $xmlWriter, SitemapIndexInterface $sitemapIndex)
+    public function write(SitemapIndexInterface $sitemapIndex, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('sitemapindex');
         $xmlWriter->writeAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
 
         foreach ($sitemapIndex->getSitemaps() as $sitemap) {
-            $this->sitemapWriter->write($xmlWriter, $sitemap);
+            $this->sitemapWriter->write($sitemap, $xmlWriter);
         }
 
         $xmlWriter->endElement();

--- a/src/Writer/SitemapWriter.php
+++ b/src/Writer/SitemapWriter.php
@@ -17,7 +17,7 @@ use XMLWriter;
  */
 class SitemapWriter
 {
-    public function write(XMLWriter $xmlWriter, SitemapInterface $sitemap)
+    public function write(SitemapInterface $sitemap, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('sitemap');
 

--- a/src/Writer/UrlSetWriter.php
+++ b/src/Writer/UrlSetWriter.php
@@ -30,7 +30,7 @@ class UrlSetWriter
         $this->urlWriter = $urlWriter ?: new UrlWriter();
     }
 
-    public function write(XMLWriter $xmlWriter, UrlSetInterface $urlSet)
+    public function write(UrlSetInterface $urlSet, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('urlset');
 
@@ -55,7 +55,7 @@ class UrlSetWriter
     private function writeUrls(XMLWriter $xmlWriter, array $urls)
     {
         foreach ($urls as $url) {
-            $this->urlWriter->write($xmlWriter, $url);
+            $this->urlWriter->write($url, $xmlWriter);
         }
     }
 }

--- a/src/Writer/UrlWriter.php
+++ b/src/Writer/UrlWriter.php
@@ -48,7 +48,7 @@ class UrlWriter
         $this->videoWriter = $videoWriter ?: new VideoWriter();
     }
 
-    public function write(XMLWriter $xmlWriter, UrlInterface $url)
+    public function write(UrlInterface $url, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('url');
 
@@ -110,7 +110,7 @@ class UrlWriter
     private function writeImages(XMLWriter $xmlWriter, array $images = [])
     {
         foreach ($images as $image) {
-            $this->imageWriter->write($xmlWriter, $image);
+            $this->imageWriter->write($image, $xmlWriter);
         }
     }
 
@@ -121,7 +121,7 @@ class UrlWriter
     private function writeNews(XMLWriter $xmlWriter, array $news = [])
     {
         foreach ($news as $pieceOfNews) {
-            $this->newsWriter->write($xmlWriter, $pieceOfNews);
+            $this->newsWriter->write($pieceOfNews, $xmlWriter);
         }
     }
 
@@ -132,7 +132,7 @@ class UrlWriter
     private function writeVideos(XMLWriter $xmlWriter, array $videos = [])
     {
         foreach ($videos as $video) {
-            $this->videoWriter->write($xmlWriter, $video);
+            $this->videoWriter->write($video, $xmlWriter);
         }
     }
 }

--- a/src/Writer/Video/GalleryLocationWriter.php
+++ b/src/Writer/Video/GalleryLocationWriter.php
@@ -16,7 +16,7 @@ use XMLWriter;
  */
 class GalleryLocationWriter
 {
-    public function write(XMLWriter $xmlWriter, GalleryLocationInterface $galleryLocation)
+    public function write(GalleryLocationInterface $galleryLocation, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('video:gallery_loc');
 

--- a/src/Writer/Video/PlatformWriter.php
+++ b/src/Writer/Video/PlatformWriter.php
@@ -16,7 +16,7 @@ use XMLWriter;
  */
 class PlatformWriter
 {
-    public function write(XMLWriter $xmlWriter, PlatformInterface $platform)
+    public function write(PlatformInterface $platform, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('video:platform');
         $xmlWriter->writeAttribute('relationship', $platform->getRelationship());

--- a/src/Writer/Video/PlayerLocationWriter.php
+++ b/src/Writer/Video/PlayerLocationWriter.php
@@ -16,7 +16,7 @@ use XMLWriter;
  */
 class PlayerLocationWriter
 {
-    public function write(XMLWriter $xmlWriter, PlayerLocationInterface $playerLocation)
+    public function write(PlayerLocationInterface $playerLocation, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('video:player_loc');
 

--- a/src/Writer/Video/PriceWriter.php
+++ b/src/Writer/Video/PriceWriter.php
@@ -16,7 +16,7 @@ use XMLWriter;
  */
 class PriceWriter
 {
-    public function write(XMLWriter $xmlWriter, PriceInterface $price)
+    public function write(PriceInterface $price, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('video:price');
         $xmlWriter->writeAttribute('currency', $price->getCurrency());

--- a/src/Writer/Video/RestrictionWriter.php
+++ b/src/Writer/Video/RestrictionWriter.php
@@ -16,7 +16,7 @@ use XMLWriter;
  */
 class RestrictionWriter
 {
-    public function write(XMLWriter $xmlWriter, RestrictionInterface $restriction)
+    public function write(RestrictionInterface $restriction, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('video:restriction');
         $xmlWriter->writeAttribute('relationship', $restriction->getRelationship());

--- a/src/Writer/Video/TagWriter.php
+++ b/src/Writer/Video/TagWriter.php
@@ -16,7 +16,7 @@ use XMLWriter;
  */
 class TagWriter
 {
-    public function write(XMLWriter $xmlWriter, TagInterface $tag)
+    public function write(TagInterface $tag, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('video:tag');
         $xmlWriter->text($tag->getContent());

--- a/src/Writer/Video/UploaderWriter.php
+++ b/src/Writer/Video/UploaderWriter.php
@@ -16,7 +16,7 @@ use XMLWriter;
  */
 class UploaderWriter
 {
-    public function write(XMLWriter $xmlWriter, UploaderInterface $uploader)
+    public function write(UploaderInterface $uploader, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('video:uploader');
 

--- a/src/Writer/Video/VideoWriter.php
+++ b/src/Writer/Video/VideoWriter.php
@@ -77,7 +77,7 @@ class VideoWriter
         $this->tagWriter = $tagWriter ?: new TagWriter();
     }
 
-    public function write(XMLWriter $xmlWriter, VideoInterface $video)
+    public function write(VideoInterface $video, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('video:video');
 
@@ -143,7 +143,7 @@ class VideoWriter
             return;
         }
 
-        $this->playerLocationWriter->write($xmlWriter, $playerLocation);
+        $this->playerLocationWriter->write($playerLocation, $xmlWriter);
     }
 
     private function writeGalleryLocation(XMLWriter $xmlWriter, GalleryLocationInterface $galleryLocation = null)
@@ -152,7 +152,7 @@ class VideoWriter
             return;
         }
 
-        $this->galleryLocationWriter->write($xmlWriter, $galleryLocation);
+        $this->galleryLocationWriter->write($galleryLocation, $xmlWriter);
     }
 
     /**
@@ -244,7 +244,7 @@ class VideoWriter
     private function writeTags(XMLWriter $xmlWriter, array $tags)
     {
         foreach ($tags as $tag) {
-            $this->tagWriter->write($xmlWriter, $tag);
+            $this->tagWriter->write($tag, $xmlWriter);
         }
     }
 
@@ -269,7 +269,7 @@ class VideoWriter
             return;
         }
 
-        $this->restrictionWriter->write($xmlWriter, $restriction);
+        $this->restrictionWriter->write($restriction, $xmlWriter);
     }
 
     /**
@@ -279,7 +279,7 @@ class VideoWriter
     private function writePrices(XMLWriter $xmlWriter, array $prices)
     {
         foreach ($prices as $price) {
-            $this->priceWriter->write($xmlWriter, $price);
+            $this->priceWriter->write($price, $xmlWriter);
         }
     }
 
@@ -304,7 +304,7 @@ class VideoWriter
             return;
         }
 
-        $this->uploaderWriter->write($xmlWriter, $uploader);
+        $this->uploaderWriter->write($uploader, $xmlWriter);
     }
 
     private function writePlatform(XMLWriter $xmlWriter, PlatformInterface $platform = null)
@@ -313,7 +313,7 @@ class VideoWriter
             return;
         }
 
-        $this->platformWriter->write($xmlWriter, $platform);
+        $this->platformWriter->write($platform, $xmlWriter);
     }
 
     /**

--- a/test/Writer/Image/ImageWriterTest.php
+++ b/test/Writer/Image/ImageWriterTest.php
@@ -32,7 +32,7 @@ class ImageWriterTest extends AbstractTestCase
 
         $writer = new ImageWriter();
 
-        $writer->write($xmlWriter, $image);
+        $writer->write($image, $xmlWriter);
     }
 
     public function testWriteAdvancedImage()
@@ -67,7 +67,7 @@ class ImageWriterTest extends AbstractTestCase
 
         $writer = new ImageWriter();
 
-        $writer->write($xmlWriter, $image);
+        $writer->write($image, $xmlWriter);
     }
 
     /**

--- a/test/Writer/News/NewsWriterTest.php
+++ b/test/Writer/News/NewsWriterTest.php
@@ -53,14 +53,14 @@ class NewsWriterTest extends AbstractTestCase
             ->expects($this->once())
             ->method('write')
             ->with(
-                $this->identicalTo($xmlWriter),
-                $this->identicalTo($publication)
+                $this->identicalTo($publication),
+                $this->identicalTo($xmlWriter)
             )
         ;
 
         $writer = new NewsWriter($publicationWriter);
 
-        $writer->write($xmlWriter, $news);
+        $writer->write($news, $xmlWriter);
     }
 
     public function testWriteAdvancedNews()
@@ -106,14 +106,14 @@ class NewsWriterTest extends AbstractTestCase
             ->expects($this->once())
             ->method('write')
             ->with(
-                $this->identicalTo($xmlWriter),
-                $this->identicalTo($publication)
+                $this->identicalTo($publication),
+                $this->identicalTo($xmlWriter)
             )
         ;
 
         $writer = new NewsWriter($publicationWriter);
 
-        $writer->write($xmlWriter, $news);
+        $writer->write($news, $xmlWriter);
     }
 
     /**

--- a/test/Writer/News/PublicationWriterTest.php
+++ b/test/Writer/News/PublicationWriterTest.php
@@ -38,7 +38,7 @@ class PublicationWriterTest extends AbstractTestCase
 
         $writer = new PublicationWriter();
 
-        $writer->write($xmlWriter, $publication);
+        $writer->write($publication, $xmlWriter);
     }
 
     /**

--- a/test/Writer/SitemapIndexWriterTest.php
+++ b/test/Writer/SitemapIndexWriterTest.php
@@ -46,15 +46,15 @@ class SitemapIndexWriterTest extends AbstractTestCase
                 ->expects($this->at($i))
                 ->method('write')
                 ->with(
-                    $this->identicalTo($xmlWriter),
-                    $this->identicalTo($sitemap)
+                    $this->identicalTo($sitemap),
+                    $this->identicalTo($xmlWriter)
                 )
             ;
         }
 
         $writer = new SitemapIndexWriter($sitemapWriter);
 
-        $writer->write($xmlWriter, $sitemapIndex);
+        $writer->write($sitemapIndex, $xmlWriter);
     }
 
     /**

--- a/test/Writer/SitemapWriterTest.php
+++ b/test/Writer/SitemapWriterTest.php
@@ -33,7 +33,7 @@ class SitemapWriterTest extends AbstractTestCase
 
         $writer = new SitemapWriter();
 
-        $writer->write($xmlWriter, $sitemap);
+        $writer->write($sitemap, $xmlWriter);
     }
 
     public function testWriteAdvancedSitemap()
@@ -59,7 +59,7 @@ class SitemapWriterTest extends AbstractTestCase
 
         $writer = new SitemapWriter();
 
-        $writer->write($xmlWriter, $sitemap);
+        $writer->write($sitemap, $xmlWriter);
     }
 
     /**

--- a/test/Writer/UrlSetWriterTest.php
+++ b/test/Writer/UrlSetWriterTest.php
@@ -52,8 +52,8 @@ class UrlSetWriterTest extends AbstractTestCase
                 ->expects($this->at($i))
                 ->method('write')
                 ->with(
-                    $this->identicalTo($xmlWriter),
-                    $this->identicalTo($url)
+                    $this->identicalTo($url),
+                    $this->identicalTo($xmlWriter)
                 )
             ;
         }
@@ -62,7 +62,7 @@ class UrlSetWriterTest extends AbstractTestCase
 
         $writer = new UrlSetWriter($urlWriter);
 
-        $writer->write($xmlWriter, $urlSet);
+        $writer->write($urlSet, $xmlWriter);
     }
 
     /**

--- a/test/Writer/UrlWriterTest.php
+++ b/test/Writer/UrlWriterTest.php
@@ -43,7 +43,7 @@ class UrlWriterTest extends AbstractTestCase
             $this->getVideoWriterMock()
         );
 
-        $writer->write($xmlWriter, $url);
+        $writer->write($url, $xmlWriter);
     }
 
     public function testWriteAdvancedUrl()
@@ -108,7 +108,7 @@ class UrlWriterTest extends AbstractTestCase
             $videoWriter
         );
 
-        $writer->write($xmlWriter, $url);
+        $writer->write($url, $xmlWriter);
     }
 
     /**
@@ -209,8 +209,8 @@ class UrlWriterTest extends AbstractTestCase
                 ->expects($this->at($i))
                 ->method('write')
                 ->with(
-                    $this->identicalTo($xmlWriter),
-                    $this->identicalTo($image)
+                    $this->identicalTo($image),
+                    $this->identicalTo($xmlWriter)
                 )
             ;
         }
@@ -252,8 +252,8 @@ class UrlWriterTest extends AbstractTestCase
                 ->expects($this->at($i))
                 ->method('write')
                 ->with(
-                    $this->identicalTo($xmlWriter),
-                    $this->identicalTo($pieceOfNews)
+                    $this->identicalTo($pieceOfNews),
+                    $this->identicalTo($xmlWriter)
                 )
             ;
         }
@@ -295,8 +295,8 @@ class UrlWriterTest extends AbstractTestCase
                 ->expects($this->at($i))
                 ->method('write')
                 ->with(
-                    $this->identicalTo($xmlWriter),
-                    $this->identicalTo($video)
+                    $this->identicalTo($video),
+                    $this->identicalTo($xmlWriter)
                 )
             ;
         }

--- a/test/Writer/Video/GalleryLocationWriterTest.php
+++ b/test/Writer/Video/GalleryLocationWriterTest.php
@@ -29,7 +29,7 @@ class GalleryLocationWriterTest extends AbstractTestCase
 
         $writer = new GalleryLocationWriter();
 
-        $writer->write($xmlWriter, $galleryLocation);
+        $writer->write($galleryLocation, $xmlWriter);
     }
 
     public function testWriteAdvancedGalleryLocation()
@@ -52,7 +52,7 @@ class GalleryLocationWriterTest extends AbstractTestCase
 
         $writer = new GalleryLocationWriter();
 
-        $writer->write($xmlWriter, $galleryLocation);
+        $writer->write($galleryLocation, $xmlWriter);
     }
 
     /**

--- a/test/Writer/Video/PlatformWriterTest.php
+++ b/test/Writer/Video/PlatformWriterTest.php
@@ -43,7 +43,7 @@ class PlatformWriterTest extends AbstractTestCase
 
         $writer = new PlatformWriter();
 
-        $writer->write($xmlWriter, $platform);
+        $writer->write($platform, $xmlWriter);
     }
 
     /**

--- a/test/Writer/Video/PlayerLocationWriterTest.php
+++ b/test/Writer/Video/PlayerLocationWriterTest.php
@@ -29,7 +29,7 @@ class PlayerLocationWriterTest extends AbstractTestCase
 
         $writer = new PlayerLocationWriter();
 
-        $writer->write($xmlWriter, $playerLocation);
+        $writer->write($playerLocation, $xmlWriter);
     }
 
     public function testWriteAdvancedPlayerLocation()
@@ -58,7 +58,7 @@ class PlayerLocationWriterTest extends AbstractTestCase
 
         $writer = new PlayerLocationWriter();
 
-        $writer->write($xmlWriter, $playerLocation);
+        $writer->write($playerLocation, $xmlWriter);
     }
 
     /**

--- a/test/Writer/Video/PriceWriterTest.php
+++ b/test/Writer/Video/PriceWriterTest.php
@@ -35,7 +35,7 @@ class PriceWriterTest extends AbstractTestCase
 
         $writer = new PriceWriter();
 
-        $writer->write($xmlWriter, $price);
+        $writer->write($price, $xmlWriter);
     }
 
     public function testWriteWithAdvancedPrice()
@@ -70,7 +70,7 @@ class PriceWriterTest extends AbstractTestCase
 
         $writer = new PriceWriter();
 
-        $writer->write($xmlWriter, $price);
+        $writer->write($price, $xmlWriter);
     }
 
     /**

--- a/test/Writer/Video/RestrictionWriterTest.php
+++ b/test/Writer/Video/RestrictionWriterTest.php
@@ -43,7 +43,7 @@ class RestrictionWriterTest extends AbstractTestCase
 
         $writer = new RestrictionWriter();
 
-        $writer->write($xmlWriter, $restriction);
+        $writer->write($restriction, $xmlWriter);
     }
 
     /**

--- a/test/Writer/Video/TagWriterTest.php
+++ b/test/Writer/Video/TagWriterTest.php
@@ -27,7 +27,7 @@ class TagWriterTest extends AbstractTestCase
 
         $writer = new TagWriter();
 
-        $writer->write($xmlWriter, $tag);
+        $writer->write($tag, $xmlWriter);
     }
 
     /**

--- a/test/Writer/Video/UploaderWriterTest.php
+++ b/test/Writer/Video/UploaderWriterTest.php
@@ -27,7 +27,7 @@ class UploaderWriterTest extends AbstractTestCase
 
         $writer = new UploaderWriter();
 
-        $writer->write($xmlWriter, $uploader);
+        $writer->write($uploader, $xmlWriter);
     }
 
     public function testWriteWithAdvancedUploader()
@@ -50,7 +50,7 @@ class UploaderWriterTest extends AbstractTestCase
 
         $writer = new UploaderWriter();
 
-        $writer->write($xmlWriter, $uploader);
+        $writer->write($uploader, $xmlWriter);
     }
 
     /**

--- a/test/Writer/Video/VideoWriterTest.php
+++ b/test/Writer/Video/VideoWriterTest.php
@@ -77,7 +77,7 @@ class VideoWriterTest extends AbstractTestCase
             $this->getTagWriterMock()
         );
 
-        $writer->write($xmlWriter, $video);
+        $writer->write($video, $xmlWriter);
     }
 
     public function testWriteAdvancedVideo()
@@ -183,7 +183,7 @@ class VideoWriterTest extends AbstractTestCase
             $tagWriter
         );
 
-        $writer->write($xmlWriter, $video);
+        $writer->write($video, $xmlWriter);
     }
 
     /**
@@ -389,8 +389,8 @@ class VideoWriterTest extends AbstractTestCase
             ->expects($this->once())
             ->method('write')
             ->with(
-                $this->identicalTo($xmlWriter),
-                $this->identicalTo($galleryLocation)
+                $this->identicalTo($galleryLocation),
+                $this->identicalTo($xmlWriter)
             )
         ;
 
@@ -427,8 +427,8 @@ class VideoWriterTest extends AbstractTestCase
             ->expects($this->once())
             ->method('write')
             ->with(
-                $this->identicalTo($xmlWriter),
-                $this->identicalTo($platform)
+                $this->identicalTo($platform),
+                $this->identicalTo($xmlWriter)
             )
         ;
 
@@ -465,8 +465,8 @@ class VideoWriterTest extends AbstractTestCase
             ->expects($this->once())
             ->method('write')
             ->with(
-                $this->identicalTo($xmlWriter),
-                $this->identicalTo($playerLocation)
+                $this->identicalTo($playerLocation),
+                $this->identicalTo($xmlWriter)
             )
         ;
 
@@ -504,8 +504,8 @@ class VideoWriterTest extends AbstractTestCase
                 ->expects($this->at($i))
                 ->method('write')
                 ->with(
-                    $this->identicalTo($xmlWriter),
-                    $this->identicalTo($price)
+                    $this->identicalTo($price),
+                    $this->identicalTo($xmlWriter)
                 )
             ;
         }
@@ -543,8 +543,8 @@ class VideoWriterTest extends AbstractTestCase
             ->expects($this->once())
             ->method('write')
             ->with(
-                $this->identicalTo($xmlWriter),
-                $this->identicalTo($restriction)
+                $this->identicalTo($restriction),
+                $this->identicalTo($xmlWriter)
             )
         ;
 
@@ -582,8 +582,8 @@ class VideoWriterTest extends AbstractTestCase
                 ->expects($this->at($i))
                 ->method('write')
                 ->with(
-                    $this->identicalTo($xmlWriter),
-                    $this->identicalTo($tag)
+                    $this->identicalTo($tag),
+                    $this->identicalTo($xmlWriter)
                 )
             ;
         }
@@ -613,8 +613,8 @@ class VideoWriterTest extends AbstractTestCase
             ->expects($this->once())
             ->method('write')
             ->with(
-                $this->identicalTo($xmlWriter),
-                $this->identicalTo($uploader)
+                $this->identicalTo($uploader),
+                $this->identicalTo($xmlWriter)
             )
         ;
 


### PR DESCRIPTION
This PR

* [x] flips the arguments passed to a writer when writing a component  

:information_desk_person: The problem is this

* the documentation is currently wrong
* for the outmost writers, the `XmlWriter` needs to be made an optional argument
* consistency wins (inner writers should also have flipped arguments)