### PR TITLE
Fix: Mark internal writers as internal

### DIFF
--- a/src/Writer/SitemapWriter.php
+++ b/src/Writer/SitemapWriter.php
@@ -14,6 +14,8 @@ use XMLWriter;
 
 /**
  * @link https://support.google.com/webmasters/answer/75712?rd=1
+ *
+ * @internal
  */
 class SitemapWriter
 {

--- a/src/Writer/UrlWriter.php
+++ b/src/Writer/UrlWriter.php
@@ -20,6 +20,8 @@ use XMLWriter;
 
 /**
  * @link https://support.google.com/webmasters/answer/183668?hl=en
+ *
+ * @internal
  */
 class UrlWriter
 {

--- a/src/Writer/Video/GalleryLocationWriter.php
+++ b/src/Writer/Video/GalleryLocationWriter.php
@@ -13,6 +13,8 @@ use XMLWriter;
 
 /**
  * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+ *
+ * @internal
  */
 class GalleryLocationWriter
 {

--- a/src/Writer/Video/PlatformWriter.php
+++ b/src/Writer/Video/PlatformWriter.php
@@ -13,6 +13,8 @@ use XMLWriter;
 
 /**
  * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+ *
+ * @internal
  */
 class PlatformWriter
 {

--- a/src/Writer/Video/PlayerLocationWriter.php
+++ b/src/Writer/Video/PlayerLocationWriter.php
@@ -13,6 +13,8 @@ use XMLWriter;
 
 /**
  * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+ *
+ * @internal
  */
 class PlayerLocationWriter
 {

--- a/src/Writer/Video/PriceWriter.php
+++ b/src/Writer/Video/PriceWriter.php
@@ -13,6 +13,8 @@ use XMLWriter;
 
 /**
  * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+ *
+ * @internal
  */
 class PriceWriter
 {

--- a/src/Writer/Video/RestrictionWriter.php
+++ b/src/Writer/Video/RestrictionWriter.php
@@ -13,6 +13,8 @@ use XMLWriter;
 
 /**
  * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+ *
+ * @internal
  */
 class RestrictionWriter
 {

--- a/src/Writer/Video/TagWriter.php
+++ b/src/Writer/Video/TagWriter.php
@@ -13,6 +13,8 @@ use XMLWriter;
 
 /**
  * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+ *
+ * @internal
  */
 class TagWriter
 {

--- a/src/Writer/Video/UploaderWriter.php
+++ b/src/Writer/Video/UploaderWriter.php
@@ -13,6 +13,8 @@ use XMLWriter;
 
 /**
  * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+ *
+ * @internal
  */
 class UploaderWriter
 {

--- a/src/Writer/Video/VideoWriter.php
+++ b/src/Writer/Video/VideoWriter.php
@@ -21,6 +21,8 @@ use XMLWriter;
 
 /**
  * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions
+ *
+ * @internal
  */
 class VideoWriter
 {


### PR DESCRIPTION
This PR

* [x] marks internal writers as internal  

:information_desk_person: The idea is this, while it's of course possible to create components and just use one of the corresponding writers marked as internal here, as someone consuming the package you're mostly interested in either generating 

* a `Component\SitemapIndex` and then using a `Writer\SitemapIndexWriter`, see https://support.google.com/webmasters/answer/75712?rd=1:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
      <loc>http://www.example.com/sitemap1.xml.gz</loc>
      <lastmod>2004-10-01T18:23:17+00:00</lastmod>
   </sitemap>
   <sitemap>
      <loc>http://www.example.com/sitemap2.xml.gz</loc>
      <lastmod>2005-01-01</lastmod>
   </sitemap>
</sitemapindex>
```

* a `Component\UrlSet` and then using a `Writer\UrlSetWriter`, see https://support.google.com/webmasters/answer/183668?hl=en: 

```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" 
  xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" 
  xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
  <url> 
    <loc>http://www.example.com/foo.html</loc> 
    <image:image>
       <image:loc>http://example.com/image.jpg</image:loc>
       <image:caption>Dogs playing poker</image:caption>
    </image:image>
    <video:video>
      <video:content_loc>
        http://www.example.com/video123.flv
      </video:content_loc>
      <video:player_loc allow_embed="yes" autoplay="ap=1">
        http://www.example.com/videoplayer.swf?video=123
      </video:player_loc>
      <video:thumbnail_loc>
        http://www.example.com/thumbs/123.jpg
      </video:thumbnail_loc>
      <video:title>Grilling steaks for summer</video:title>  
      <video:description>
        Cook the perfect steak every time.
      </video:description>
    </video:video>
  </url>
</urlset>
```

By marking the writers as internal it's more clear that one shouldn't rely on them.