### PR TITLE
Fix: Actually start and end documents

### DIFF
--- a/src/Writer/SitemapIndexWriter.php
+++ b/src/Writer/SitemapIndexWriter.php
@@ -28,6 +28,8 @@ class SitemapIndexWriter
 
     public function write(SitemapIndexInterface $sitemapIndex, XMLWriter $xmlWriter)
     {
+        $xmlWriter->startDocument('1.0', 'UTF-8');
+
         $xmlWriter->startElement('sitemapindex');
         $xmlWriter->writeAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
 
@@ -36,5 +38,7 @@ class SitemapIndexWriter
         }
 
         $xmlWriter->endElement();
+
+        $xmlWriter->endDocument();
     }
 }

--- a/src/Writer/UrlSetWriter.php
+++ b/src/Writer/UrlSetWriter.php
@@ -32,12 +32,16 @@ class UrlSetWriter
 
     public function write(UrlSetInterface $urlSet, XMLWriter $xmlWriter)
     {
+        $xmlWriter->startDocument('1.0', 'UTF-8');
+
         $xmlWriter->startElement('urlset');
 
         $this->writeNamespaceAttributes($xmlWriter);
         $this->writeUrls($xmlWriter, $urlSet->getUrls());
 
         $xmlWriter->endElement();
+
+        $xmlWriter->endDocument();
     }
 
     private function writeNamespaceAttributes(XMLWriter $xmlWriter)

--- a/test/Writer/AbstractTestCase.php
+++ b/test/Writer/AbstractTestCase.php
@@ -17,6 +17,23 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
 
     /**
      * @param \PHPUnit_Framework_MockObject_MockObject $xmlWriter
+     * @param string                                   $version
+     * @param string                                   $charset
+     */
+    protected function expectToStartDocument(\PHPUnit_Framework_MockObject_MockObject $xmlWriter, $version = '1.0', $charset = 'UTF-8')
+    {
+        $xmlWriter
+            ->expects($this->next($xmlWriter))
+            ->method('startDocument')
+            ->with(
+                $this->identicalTo($version),
+                $this->identicalTo($charset)
+            )
+        ;
+    }
+
+    /**
+     * @param \PHPUnit_Framework_MockObject_MockObject $xmlWriter
      * @param string                                   $name
      */
     protected function expectToStartElement(\PHPUnit_Framework_MockObject_MockObject $xmlWriter, $name)
@@ -53,6 +70,17 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
         $xmlWriter
             ->expects($this->next($xmlWriter))
             ->method('endElement')
+        ;
+    }
+
+    /**
+     * @param \PHPUnit_Framework_MockObject_MockObject $xmlWriter
+     */
+    protected function expectToEndDocument(\PHPUnit_Framework_MockObject_MockObject $xmlWriter)
+    {
+        $xmlWriter
+            ->expects($this->next($xmlWriter))
+            ->method('endDocument')
         ;
     }
 

--- a/test/Writer/SitemapIndexWriterTest.php
+++ b/test/Writer/SitemapIndexWriterTest.php
@@ -35,6 +35,8 @@ class SitemapIndexWriterTest extends AbstractTestCase
 
         $xmlWriter = $this->getXmlWriterMock();
 
+        $this->expectToStartDocument($xmlWriter);
+
         $this->expectToWriteElement($xmlWriter, 'sitemapindex', null, [
             'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9',
         ]);
@@ -51,6 +53,8 @@ class SitemapIndexWriterTest extends AbstractTestCase
                 )
             ;
         }
+
+        $this->expectToEndDocument($xmlWriter);
 
         $writer = new SitemapIndexWriter($sitemapWriter);
 

--- a/test/Writer/UrlSetWriterTest.php
+++ b/test/Writer/UrlSetWriterTest.php
@@ -38,6 +38,8 @@ class UrlSetWriterTest extends AbstractTestCase
 
         $xmlWriter = $this->getXmlWriterMock();
 
+        $this->expectToStartDocument($xmlWriter);
+
         $this->expectToStartElement($xmlWriter, 'urlset');
 
         $this->expectToWriteAttribute($xmlWriter, UrlSetInterface::XML_NAMESPACE_ATTRIBUTE, UrlSetInterface::XML_NAMESPACE_URI);
@@ -59,6 +61,8 @@ class UrlSetWriterTest extends AbstractTestCase
         }
 
         $this->expectToEndElement($xmlWriter);
+
+        $this->expectToEndDocument($xmlWriter);
 
         $writer = new UrlSetWriter($urlWriter);
 


### PR DESCRIPTION
This PR

* [x] asserts that the `XmlWriter` used by `SitemapIndexWriter` and `UrlSetWriter` actually starts and ends a document  
* [x]  actually starts and ends documents
