### PR TITLE
Enhancement: Return generated XML from writers

### DIFF
--- a/src/Writer/SitemapIndexWriter.php
+++ b/src/Writer/SitemapIndexWriter.php
@@ -26,6 +26,12 @@ class SitemapIndexWriter
         $this->sitemapWriter = $sitemapWriter ?: new SitemapWriter();
     }
 
+    /**
+     * @param SitemapIndexInterface $sitemapIndex
+     * @param XMLWriter             $xmlWriter
+     *
+     * @return string
+     */
     public function write(SitemapIndexInterface $sitemapIndex, XMLWriter $xmlWriter)
     {
         $xmlWriter->startDocument('1.0', 'UTF-8');
@@ -40,5 +46,7 @@ class SitemapIndexWriter
         $xmlWriter->endElement();
 
         $xmlWriter->endDocument();
+
+        return $xmlWriter->outputMemory();
     }
 }

--- a/src/Writer/UrlSetWriter.php
+++ b/src/Writer/UrlSetWriter.php
@@ -30,6 +30,12 @@ class UrlSetWriter
         $this->urlWriter = $urlWriter ?: new UrlWriter();
     }
 
+    /**
+     * @param UrlSetInterface $urlSet
+     * @param XMLWriter       $xmlWriter
+     *
+     * @return string
+     */
     public function write(UrlSetInterface $urlSet, XMLWriter $xmlWriter)
     {
         $xmlWriter->startDocument('1.0', 'UTF-8');
@@ -42,6 +48,8 @@ class UrlSetWriter
         $xmlWriter->endElement();
 
         $xmlWriter->endDocument();
+
+        return $xmlWriter->outputMemory();
     }
 
     private function writeNamespaceAttributes(XMLWriter $xmlWriter)

--- a/test/Writer/AbstractTestCase.php
+++ b/test/Writer/AbstractTestCase.php
@@ -110,6 +110,19 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @param \PHPUnit_Framework_MockObject_MockObject $xmlWriter
+     * @param string                                   $output
+     */
+    protected function expectToOutput($xmlWriter, $output)
+    {
+        $xmlWriter
+            ->expects($this->next($xmlWriter))
+            ->method('outputMemory')
+            ->willReturn($output)
+        ;
+    }
+
+    /**
      * Returns a matcher which matches the next invocation of a method on the mocked object.
      *
      * @param \PHPUnit_Framework_MockObject_MockObject $mockObject

--- a/test/Writer/SitemapIndexWriterTest.php
+++ b/test/Writer/SitemapIndexWriterTest.php
@@ -12,10 +12,13 @@ use Refinery29\Sitemap\Component\SitemapIndexInterface;
 use Refinery29\Sitemap\Component\SitemapInterface;
 use Refinery29\Sitemap\Writer\SitemapIndexWriter;
 use Refinery29\Sitemap\Writer\SitemapWriter;
+use Refinery29\Test\Util\Faker\GeneratorTrait;
 use XMLWriter;
 
 class SitemapIndexWriterTest extends AbstractTestCase
 {
+    use GeneratorTrait;
+
     public function testConstructorCreatesRequiredWriter()
     {
         $writer = new SitemapIndexWriter();
@@ -25,6 +28,8 @@ class SitemapIndexWriterTest extends AbstractTestCase
 
     public function testWriteSitemapIndex()
     {
+        $output = $this->getFaker()->text();
+
         $sitemaps = [
             $this->getSitemapMock(),
             $this->getSitemapMock(),
@@ -56,9 +61,11 @@ class SitemapIndexWriterTest extends AbstractTestCase
 
         $this->expectToEndDocument($xmlWriter);
 
+        $this->expectToOutput($xmlWriter, $output);
+
         $writer = new SitemapIndexWriter($sitemapWriter);
 
-        $writer->write($sitemapIndex, $xmlWriter);
+        $this->assertSame($output, $writer->write($sitemapIndex, $xmlWriter));
     }
 
     /**

--- a/test/Writer/UrlSetWriterTest.php
+++ b/test/Writer/UrlSetWriterTest.php
@@ -28,6 +28,8 @@ class UrlSetWriterTest extends AbstractTestCase
 
     public function testWriteUrlSet()
     {
+        $output = $this->getFaker()->text();
+
         $urls = [
             $this->getUrlMock(),
             $this->getUrlMock(),
@@ -63,10 +65,11 @@ class UrlSetWriterTest extends AbstractTestCase
         $this->expectToEndElement($xmlWriter);
 
         $this->expectToEndDocument($xmlWriter);
+        $this->expectToOutput($xmlWriter, $output);
 
         $writer = new UrlSetWriter($urlWriter);
 
-        $writer->write($urlSet, $xmlWriter);
+        $this->assertSame($output, $writer->write($urlSet, $xmlWriter));
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] adjusts outer writers to return the generated XML  

Follows #44.

:information_desk_person: This is what we're most interested in, right?!
