### PR TITLE
Fix: Make XMLWriter an optional argument

### DIFF
--- a/src/Writer/SitemapIndexWriter.php
+++ b/src/Writer/SitemapIndexWriter.php
@@ -32,8 +32,10 @@ class SitemapIndexWriter
      *
      * @return string
      */
-    public function write(SitemapIndexInterface $sitemapIndex, XMLWriter $xmlWriter)
+    public function write(SitemapIndexInterface $sitemapIndex, XMLWriter $xmlWriter = null)
     {
+        $xmlWriter = $xmlWriter ?: new XMLWriter();
+
         $xmlWriter->openMemory();
         $xmlWriter->startDocument('1.0', 'UTF-8');
 

--- a/src/Writer/UrlSetWriter.php
+++ b/src/Writer/UrlSetWriter.php
@@ -36,8 +36,10 @@ class UrlSetWriter
      *
      * @return string
      */
-    public function write(UrlSetInterface $urlSet, XMLWriter $xmlWriter)
+    public function write(UrlSetInterface $urlSet, XMLWriter $xmlWriter = null)
     {
+        $xmlWriter = $xmlWriter ?: new XMLWriter();
+
         $xmlWriter->openMemory();
         $xmlWriter->startDocument('1.0', 'UTF-8');
 

--- a/test/Integration/Writer/SitemapIndexWriterTest.php
+++ b/test/Integration/Writer/SitemapIndexWriterTest.php
@@ -12,7 +12,6 @@ use DateTimeImmutable;
 use Refinery29\Sitemap\Component\Sitemap;
 use Refinery29\Sitemap\Component\SitemapIndex;
 use Refinery29\Sitemap\Writer\SitemapIndexWriter;
-use XMLWriter;
 
 class SitemapIndexWriterTest extends \PHPUnit_Framework_TestCase
 {
@@ -37,6 +36,6 @@ XML;
 
         $writer = new SitemapIndexWriter();
 
-        $this->assertXmlStringEqualsXmlString($expected, $writer->write($index, new XMLWriter()));
+        $this->assertXmlStringEqualsXmlString($expected, $writer->write($index));
     }
 }

--- a/test/Integration/Writer/UrlSetWriterTest.php
+++ b/test/Integration/Writer/UrlSetWriterTest.php
@@ -10,7 +10,6 @@ namespace Refinery29\Sitemap\Test\Integration\Writer;
 
 use Refinery29\Sitemap\Component;
 use Refinery29\Sitemap\Writer;
-use XMLWriter;
 
 class UrlSetWriterTest extends \PHPUnit_Framework_TestCase
 {
@@ -31,7 +30,7 @@ class UrlSetWriterTest extends \PHPUnit_Framework_TestCase
 </urlset>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $writer->write($urlSet, new XMLWriter()));
+        $this->assertXmlStringEqualsXmlString($expected, $writer->write($urlSet));
     }
 
     public function testWriteSitemapWithMoreComponents()
@@ -82,6 +81,6 @@ XML;
 </urlset>
 XML;
 
-        $this->assertXmlStringEqualsXmlString($expected, $writer->write($urlSet, new XMLWriter()));
+        $this->assertXmlStringEqualsXmlString($expected, $writer->write($urlSet));
     }
 }


### PR DESCRIPTION
This PR

* [x] asserts that an `XMLWriter` does not need to be passed in to outer writers  
* [x] creates `XMLWriter` if not passed in 

Follows #52.

