### PR TITLE
Fix: Drop prefix from accessors

### DIFF
--- a/src/Component/Image/Image.php
+++ b/src/Component/Image/Image.php
@@ -51,27 +51,27 @@ final class Image implements ImageInterface
         $this->licence = $licence;
     }
 
-    public function getLocation()
+    public function location()
     {
         return $this->location;
     }
 
-    public function getTitle()
+    public function title()
     {
         return $this->title;
     }
 
-    public function getCaption()
+    public function caption()
     {
         return $this->caption;
     }
 
-    public function getGeoLocation()
+    public function geoLocation()
     {
         return $this->geoLocation;
     }
 
-    public function getLicence()
+    public function licence()
     {
         return $this->licence;
     }

--- a/src/Component/Image/ImageInterface.php
+++ b/src/Component/Image/ImageInterface.php
@@ -22,25 +22,25 @@ interface ImageInterface
     /**
      * @return string
      */
-    public function getLocation();
+    public function location();
 
     /**
      * @return string|null
      */
-    public function getTitle();
+    public function title();
 
     /**
      * @return string|null
      */
-    public function getCaption();
+    public function caption();
 
     /**
      * @return string|null
      */
-    public function getGeoLocation();
+    public function geoLocation();
 
     /**
      * @return string|null
      */
-    public function getLicence();
+    public function licence();
 }

--- a/src/Component/News/News.php
+++ b/src/Component/News/News.php
@@ -78,17 +78,17 @@ final class News implements NewsInterface
         $this->setStockTickers($stockTickers);
     }
 
-    public function getPublication()
+    public function publication()
     {
         return $this->publication;
     }
 
-    public function getPublicationDate()
+    public function publicationDate()
     {
         return clone $this->publicationDate;
     }
 
-    public function getTitle()
+    public function title()
     {
         return $this->title;
     }
@@ -108,7 +108,7 @@ final class News implements NewsInterface
         $this->access = $access;
     }
 
-    public function getAccess()
+    public function access()
     {
         return $this->access;
     }
@@ -131,12 +131,12 @@ final class News implements NewsInterface
         $this->genres = $genres;
     }
 
-    public function getGenres()
+    public function genres()
     {
         return $this->genres;
     }
 
-    public function getKeywords()
+    public function keywords()
     {
         return $this->keywords;
     }
@@ -151,7 +151,7 @@ final class News implements NewsInterface
         $this->stockTickers = $stockTickers;
     }
 
-    public function getStockTickers()
+    public function stockTickers()
     {
         return $this->stockTickers;
     }

--- a/src/Component/News/NewsInterface.php
+++ b/src/Component/News/NewsInterface.php
@@ -50,35 +50,35 @@ interface NewsInterface
     /**
      * @return PublicationInterface
      */
-    public function getPublication();
+    public function publication();
 
     /**
      * @return DateTimeInterface
      */
-    public function getPublicationDate();
+    public function publicationDate();
 
     /**
      * @return string
      */
-    public function getTitle();
+    public function title();
 
     /**
      * @return string|null
      */
-    public function getAccess();
+    public function access();
 
     /**
      * @return array
      */
-    public function getGenres();
+    public function genres();
 
     /**
      * @return array
      */
-    public function getKeywords();
+    public function keywords();
 
     /**
      * @return array
      */
-    public function getStockTickers();
+    public function stockTickers();
 }

--- a/src/Component/News/Publication.php
+++ b/src/Component/News/Publication.php
@@ -30,12 +30,12 @@ final class Publication implements PublicationInterface
         $this->language = $language;
     }
 
-    public function getName()
+    public function name()
     {
         return $this->name;
     }
 
-    public function getLanguage()
+    public function language()
     {
         return $this->language;
     }

--- a/src/Component/News/PublicationInterface.php
+++ b/src/Component/News/PublicationInterface.php
@@ -16,10 +16,10 @@ interface PublicationInterface
     /**
      * @return string
      */
-    public function getName();
+    public function name();
 
     /**
      * @return string
      */
-    public function getLanguage();
+    public function language();
 }

--- a/src/Component/Sitemap.php
+++ b/src/Component/Sitemap.php
@@ -32,12 +32,12 @@ final class Sitemap implements SitemapInterface
         $this->lastModified = $lastModified;
     }
 
-    public function getLocation()
+    public function location()
     {
         return $this->location;
     }
 
-    public function getLastModified()
+    public function lastModified()
     {
         if ($this->lastModified === null) {
             return;

--- a/src/Component/SitemapIndex.php
+++ b/src/Component/SitemapIndex.php
@@ -17,10 +17,10 @@ final class SitemapIndex implements SitemapIndexInterface
 
     public function addSitemap(SitemapInterface $sitemap)
     {
-        if ($this->hasSitemapWithLocation($sitemap->getLocation())) {
+        if ($this->hasSitemapWithLocation($sitemap->location())) {
             throw new \InvalidArgumentException(sprintf(
                 'Can not add sitemap with duplicate location "%s"',
-                $sitemap->getLocation()
+                $sitemap->location()
             ));
         }
 
@@ -35,7 +35,7 @@ final class SitemapIndex implements SitemapIndexInterface
     private function hasSitemapWithLocation($location)
     {
         foreach ($this->sitemaps as $sitemap) {
-            if ($sitemap->getLocation() === $location) {
+            if ($sitemap->location() === $location) {
                 return true;
             }
         }
@@ -43,7 +43,7 @@ final class SitemapIndex implements SitemapIndexInterface
         return false;
     }
 
-    public function getSitemaps()
+    public function sitemaps()
     {
         return $this->sitemaps;
     }

--- a/src/Component/SitemapIndexInterface.php
+++ b/src/Component/SitemapIndexInterface.php
@@ -21,5 +21,5 @@ interface SitemapIndexInterface
     /**
      * @return SitemapInterface[]
      */
-    public function getSitemaps();
+    public function sitemaps();
 }

--- a/src/Component/SitemapInterface.php
+++ b/src/Component/SitemapInterface.php
@@ -18,10 +18,10 @@ interface SitemapInterface
     /**
      * @return string
      */
-    public function getLocation();
+    public function location();
 
     /**
      * @return DateTimeInterface|null
      */
-    public function getLastModified();
+    public function lastModified();
 }

--- a/src/Component/Url.php
+++ b/src/Component/Url.php
@@ -65,12 +65,12 @@ final class Url implements UrlInterface
         $this->priority = $priority;
     }
 
-    public function getLocation()
+    public function location()
     {
         return $this->location;
     }
 
-    public function getLastModified()
+    public function lastModified()
     {
         if ($this->lastModified === null) {
             return;
@@ -79,12 +79,12 @@ final class Url implements UrlInterface
         return clone $this->lastModified;
     }
 
-    public function getChangeFrequency()
+    public function changeFrequency()
     {
         return $this->changeFrequency;
     }
 
-    public function getPriority()
+    public function priority()
     {
         return $this->priority;
     }
@@ -96,7 +96,7 @@ final class Url implements UrlInterface
         $this->images[] = $image;
     }
 
-    public function getImages()
+    public function images()
     {
         return $this->images;
     }
@@ -106,7 +106,7 @@ final class Url implements UrlInterface
         $this->news[] = $news;
     }
 
-    public function getNews()
+    public function news()
     {
         return $this->news;
     }
@@ -116,7 +116,7 @@ final class Url implements UrlInterface
         $this->videos[] = $video;
     }
 
-    public function getVideos()
+    public function videos()
     {
         return $this->videos;
     }

--- a/src/Component/UrlInterface.php
+++ b/src/Component/UrlInterface.php
@@ -36,35 +36,35 @@ interface UrlInterface
     /**
      * @return string
      */
-    public function getLocation();
+    public function location();
 
     /**
      * @return DateTimeInterface|null
      */
-    public function getLastModified();
+    public function lastModified();
 
     /**
      * @return string|null
      */
-    public function getChangeFrequency();
+    public function changeFrequency();
 
     /**
      * @return string|null
      */
-    public function getPriority();
+    public function priority();
 
     /**
      * @return Image\ImageInterface[]
      */
-    public function getImages();
+    public function images();
 
     /**
      * @return News\NewsInterface[]
      */
-    public function getNews();
+    public function news();
 
     /**
      * @return Video\VideoInterface[]
      */
-    public function getVideos();
+    public function videos();
 }

--- a/src/Component/UrlSet.php
+++ b/src/Component/UrlSet.php
@@ -24,7 +24,7 @@ final class UrlSet implements UrlSetInterface
         $this->urls[] = $url;
     }
 
-    public function getUrls()
+    public function urls()
     {
         return $this->urls;
     }

--- a/src/Component/UrlSetInterface.php
+++ b/src/Component/UrlSetInterface.php
@@ -32,5 +32,5 @@ interface UrlSetInterface
     /**
      * @return UrlInterface[]
      */
-    public function getUrls();
+    public function urls();
 }

--- a/src/Component/Video/GalleryLocation.php
+++ b/src/Component/Video/GalleryLocation.php
@@ -30,12 +30,12 @@ final class GalleryLocation implements GalleryLocationInterface
         $this->title = $title;
     }
 
-    public function getLocation()
+    public function location()
     {
         return $this->location;
     }
 
-    public function getTitle()
+    public function title()
     {
         return $this->title;
     }

--- a/src/Component/Video/GalleryLocationInterface.php
+++ b/src/Component/Video/GalleryLocationInterface.php
@@ -16,10 +16,10 @@ interface GalleryLocationInterface
     /**
      * @return string
      */
-    public function getLocation();
+    public function location();
 
     /**
      * @return string|null
      */
-    public function getTitle();
+    public function title();
 }

--- a/src/Component/Video/Platform.php
+++ b/src/Component/Video/Platform.php
@@ -45,7 +45,7 @@ final class Platform implements PlatformInterface
         $this->relationship = $relationship;
     }
 
-    public function getRelationship()
+    public function relationship()
     {
         return $this->relationship;
     }
@@ -67,7 +67,7 @@ final class Platform implements PlatformInterface
         $this->types[] = $type;
     }
 
-    public function getTypes()
+    public function types()
     {
         return $this->types;
     }

--- a/src/Component/Video/PlatformInterface.php
+++ b/src/Component/Video/PlatformInterface.php
@@ -33,10 +33,10 @@ interface PlatformInterface
     /**
      * @return string
      */
-    public function getRelationship();
+    public function relationship();
 
     /**
      * @return array
      */
-    public function getTypes();
+    public function types();
 }

--- a/src/Component/Video/PlayerLocation.php
+++ b/src/Component/Video/PlayerLocation.php
@@ -41,7 +41,7 @@ final class PlayerLocation implements PlayerLocationInterface
         $this->autoPlay = $autoPlay;
     }
 
-    public function getLocation()
+    public function location()
     {
         return $this->location;
     }
@@ -61,12 +61,12 @@ final class PlayerLocation implements PlayerLocationInterface
         $this->allowEmbed = $allowEmbed;
     }
 
-    public function getAllowEmbed()
+    public function allowEmbed()
     {
         return $this->allowEmbed;
     }
 
-    public function getAutoPlay()
+    public function autoPlay()
     {
         return $this->autoPlay;
     }

--- a/src/Component/Video/PlayerLocationInterface.php
+++ b/src/Component/Video/PlayerLocationInterface.php
@@ -24,15 +24,15 @@ interface PlayerLocationInterface
     /**
      * @return string
      */
-    public function getLocation();
+    public function location();
 
     /**
      * @return string|null
      */
-    public function getAllowEmbed();
+    public function allowEmbed();
 
     /**
      * @return string|null
      */
-    public function getAutoPlay();
+    public function autoPlay();
 }

--- a/src/Component/Video/Price.php
+++ b/src/Component/Video/Price.php
@@ -58,12 +58,12 @@ final class Price implements PriceInterface
         $this->value = $value;
     }
 
-    public function getValue()
+    public function value()
     {
         return $this->value;
     }
 
-    public function getCurrency()
+    public function currency()
     {
         return $this->currency;
     }
@@ -83,7 +83,7 @@ final class Price implements PriceInterface
         $this->type = $type;
     }
 
-    public function getType()
+    public function type()
     {
         return $this->type;
     }
@@ -103,7 +103,7 @@ final class Price implements PriceInterface
         $this->resolution = $resolution;
     }
 
-    public function getResolution()
+    public function resolution()
     {
         return $this->resolution;
     }

--- a/src/Component/Video/PriceInterface.php
+++ b/src/Component/Video/PriceInterface.php
@@ -37,20 +37,20 @@ interface PriceInterface
     /**
      * @return float
      */
-    public function getValue();
+    public function value();
 
     /**
      * @return string
      */
-    public function getCurrency();
+    public function currency();
 
     /**
      * @return string|null
      */
-    public function getType();
+    public function type();
 
     /**
      * @return string|null
      */
-    public function getResolution();
+    public function resolution();
 }

--- a/src/Component/Video/Restriction.php
+++ b/src/Component/Video/Restriction.php
@@ -48,7 +48,7 @@ final class Restriction implements RestrictionInterface
     /**
      * @return string
      */
-    public function getRelationship()
+    public function relationship()
     {
         return $this->relationship;
     }
@@ -64,7 +64,7 @@ final class Restriction implements RestrictionInterface
     /**
      * @return array
      */
-    public function getCountryCodes()
+    public function countryCodes()
     {
         return $this->countryCodes;
     }

--- a/src/Component/Video/RestrictionInterface.php
+++ b/src/Component/Video/RestrictionInterface.php
@@ -24,10 +24,10 @@ interface RestrictionInterface
     /**
      * @return string
      */
-    public function getRelationship();
+    public function relationship();
 
     /**
      * @return array
      */
-    public function getCountryCodes();
+    public function countryCodes();
 }

--- a/src/Component/Video/Tag.php
+++ b/src/Component/Video/Tag.php
@@ -26,7 +26,7 @@ final class Tag implements TagInterface
     /**
      * @return string
      */
-    public function getContent()
+    public function content()
     {
         return $this->content;
     }

--- a/src/Component/Video/TagInterface.php
+++ b/src/Component/Video/TagInterface.php
@@ -13,5 +13,5 @@ interface TagInterface
     /**
      * @return string
      */
-    public function getContent();
+    public function content();
 }

--- a/src/Component/Video/Uploader.php
+++ b/src/Component/Video/Uploader.php
@@ -30,12 +30,12 @@ final class Uploader implements UploaderInterface
         $this->info = $info;
     }
 
-    public function getName()
+    public function name()
     {
         return $this->name;
     }
 
-    public function getInfo()
+    public function info()
     {
         return $this->info;
     }

--- a/src/Component/Video/UploaderInterface.php
+++ b/src/Component/Video/UploaderInterface.php
@@ -16,10 +16,10 @@ interface UploaderInterface
     /**
      * @return string
      */
-    public function getName();
+    public function name();
 
     /**
      * @return string|null
      */
-    public function getInfo();
+    public function info();
 }

--- a/src/Component/Video/Video.php
+++ b/src/Component/Video/Video.php
@@ -190,7 +190,7 @@ final class Video implements VideoInterface
         $this->setLive($live);
     }
 
-    public function getThumbnailLocation()
+    public function thumbnailLocation()
     {
         return $this->thumbnailLocation;
     }
@@ -205,7 +205,7 @@ final class Video implements VideoInterface
         $this->title = $title;
     }
 
-    public function getTitle()
+    public function title()
     {
         return $this->title;
     }
@@ -220,22 +220,22 @@ final class Video implements VideoInterface
         $this->description = $description;
     }
 
-    public function getDescription()
+    public function description()
     {
         return $this->description;
     }
 
-    public function getContentLocation()
+    public function contentLocation()
     {
         return $this->contentLocation;
     }
 
-    public function getPlayerLocation()
+    public function playerLocation()
     {
         return $this->playerLocation;
     }
 
-    public function getGalleryLocation()
+    public function galleryLocation()
     {
         return $this->galleryLocation;
     }
@@ -255,12 +255,12 @@ final class Video implements VideoInterface
         $this->duration = $duration;
     }
 
-    public function getDuration()
+    public function duration()
     {
         return $this->duration;
     }
 
-    public function getPublicationDate()
+    public function publicationDate()
     {
         if ($this->publicationDate === null) {
             return;
@@ -269,7 +269,7 @@ final class Video implements VideoInterface
         return clone $this->publicationDate;
     }
 
-    public function getExpirationDate()
+    public function expirationDate()
     {
         if ($this->expirationDate === null) {
             return;
@@ -293,7 +293,7 @@ final class Video implements VideoInterface
         $this->rating = $rating;
     }
 
-    public function getRating()
+    public function rating()
     {
         return $this->rating;
     }
@@ -312,7 +312,7 @@ final class Video implements VideoInterface
         $this->viewCount = $viewCount;
     }
 
-    public function getViewCount()
+    public function viewCount()
     {
         return $this->viewCount;
     }
@@ -331,7 +331,7 @@ final class Video implements VideoInterface
         $this->familyFriendly = $familyFriendly;
     }
 
-    public function getFamilyFriendly()
+    public function familyFriendly()
     {
         return $this->familyFriendly;
     }
@@ -343,7 +343,7 @@ final class Video implements VideoInterface
         $this->tags[] = $tag;
     }
 
-    public function getTags()
+    public function tags()
     {
         return $this->tags;
     }
@@ -362,12 +362,12 @@ final class Video implements VideoInterface
         $this->category = $category;
     }
 
-    public function getCategory()
+    public function category()
     {
         return $this->category;
     }
 
-    public function getRestriction()
+    public function restriction()
     {
         return $this->restriction;
     }
@@ -377,7 +377,7 @@ final class Video implements VideoInterface
         $this->prices[] = $price;
     }
 
-    public function getPrices()
+    public function prices()
     {
         return $this->prices;
     }
@@ -397,17 +397,17 @@ final class Video implements VideoInterface
         $this->requiresSubscription = $requiresSubscription;
     }
 
-    public function getRequiresSubscription()
+    public function requiresSubscription()
     {
         return $this->requiresSubscription;
     }
 
-    public function getUploader()
+    public function uploader()
     {
         return $this->uploader;
     }
 
-    public function getPlatform()
+    public function platform()
     {
         return $this->platform;
     }
@@ -427,7 +427,7 @@ final class Video implements VideoInterface
         $this->live = $live;
     }
 
-    public function getLive()
+    public function live()
     {
         return $this->live;
     }

--- a/src/Component/Video/VideoInterface.php
+++ b/src/Component/Video/VideoInterface.php
@@ -91,100 +91,100 @@ interface VideoInterface
     /**
      * @return string
      */
-    public function getThumbnailLocation();
+    public function thumbnailLocation();
 
     /**
      * @return string
      */
-    public function getTitle();
+    public function title();
 
     /**
      * @return string
      */
-    public function getDescription();
+    public function description();
 
     /**
      * @return string|null
      */
-    public function getContentLocation();
+    public function contentLocation();
 
     /**
      * @return PlayerLocationInterface|null
      */
-    public function getPlayerLocation();
+    public function playerLocation();
 
     /**
      * @return GalleryLocationInterface|null
      */
-    public function getGalleryLocation();
+    public function galleryLocation();
 
     /**
      * @return int|null
      */
-    public function getDuration();
+    public function duration();
 
     /**
      * @return DateTimeInterface|null
      */
-    public function getPublicationDate();
+    public function publicationDate();
 
     /**
      * @return DateTimeInterface|null
      */
-    public function getExpirationDate();
+    public function expirationDate();
 
     /**
      * @return float|null
      */
-    public function getRating();
+    public function rating();
 
     /**
      * @return int|null
      */
-    public function getViewCount();
+    public function viewCount();
 
     /**
      * @return string|null
      */
-    public function getFamilyFriendly();
+    public function familyFriendly();
 
     /**
      * @return TagInterface[]
      */
-    public function getTags();
+    public function tags();
 
     /**
      * @return string|null
      */
-    public function getCategory();
+    public function category();
 
     /**
      * @return RestrictionInterface|null
      */
-    public function getRestriction();
+    public function restriction();
 
     /**
      * @return PriceInterface[]
      */
-    public function getPrices();
+    public function prices();
 
     /**
      * @return string|null
      */
-    public function getRequiresSubscription();
+    public function requiresSubscription();
 
     /**
      * @return UploaderInterface|null
      */
-    public function getUploader();
+    public function uploader();
 
     /**
      * @return PlatformInterface|null
      */
-    public function getPlatform();
+    public function platform();
 
     /**
      * @return string|null
      */
-    public function getLive();
+    public function live();
 }

--- a/src/Writer/Image/ImageWriter.php
+++ b/src/Writer/Image/ImageWriter.php
@@ -20,11 +20,11 @@ class ImageWriter
     {
         $xmlWriter->startElement('image:image');
 
-        $this->writeLocation($xmlWriter, $image->getLocation());
-        $this->writeTitle($xmlWriter, $image->getTitle());
-        $this->writeCaption($xmlWriter, $image->getCaption());
-        $this->writeGeoLocation($xmlWriter, $image->getGeoLocation());
-        $this->writeLicence($xmlWriter, $image->getLicence());
+        $this->writeLocation($xmlWriter, $image->location());
+        $this->writeTitle($xmlWriter, $image->title());
+        $this->writeCaption($xmlWriter, $image->caption());
+        $this->writeGeoLocation($xmlWriter, $image->geoLocation());
+        $this->writeLicence($xmlWriter, $image->licence());
 
         $xmlWriter->endElement();
     }

--- a/src/Writer/News/NewsWriter.php
+++ b/src/Writer/News/NewsWriter.php
@@ -31,14 +31,14 @@ class NewsWriter
     {
         $xmlWriter->startElement('news:news');
 
-        $this->publicationWriter->write($news->getPublication(), $xmlWriter);
+        $this->publicationWriter->write($news->publication(), $xmlWriter);
 
-        $this->writePublicationDate($xmlWriter, $news->getPublicationDate());
-        $this->writeTitle($xmlWriter, $news->getTitle());
-        $this->writeAccess($xmlWriter, $news->getAccess());
-        $this->writeGenres($xmlWriter, $news->getGenres());
-        $this->writeKeywords($xmlWriter, $news->getKeywords());
-        $this->writeStockTickers($xmlWriter, $news->getStockTickers());
+        $this->writePublicationDate($xmlWriter, $news->publicationDate());
+        $this->writeTitle($xmlWriter, $news->title());
+        $this->writeAccess($xmlWriter, $news->access());
+        $this->writeGenres($xmlWriter, $news->genres());
+        $this->writeKeywords($xmlWriter, $news->keywords());
+        $this->writeStockTickers($xmlWriter, $news->stockTickers());
 
         $xmlWriter->endElement();
     }

--- a/src/Writer/News/PublicationWriter.php
+++ b/src/Writer/News/PublicationWriter.php
@@ -20,8 +20,8 @@ class PublicationWriter
     {
         $xmlWriter->startElement('news:publication');
 
-        $this->writeName($xmlWriter, $publication->getName());
-        $this->writeLanguage($xmlWriter, $publication->getLanguage());
+        $this->writeName($xmlWriter, $publication->name());
+        $this->writeLanguage($xmlWriter, $publication->language());
 
         $xmlWriter->endElement();
     }

--- a/src/Writer/SitemapIndexWriter.php
+++ b/src/Writer/SitemapIndexWriter.php
@@ -42,7 +42,7 @@ class SitemapIndexWriter
         $xmlWriter->startElement('sitemapindex');
         $xmlWriter->writeAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
 
-        foreach ($sitemapIndex->getSitemaps() as $sitemap) {
+        foreach ($sitemapIndex->sitemaps() as $sitemap) {
             $this->sitemapWriter->write($sitemap, $xmlWriter);
         }
 

--- a/src/Writer/SitemapWriter.php
+++ b/src/Writer/SitemapWriter.php
@@ -23,8 +23,8 @@ class SitemapWriter
     {
         $xmlWriter->startElement('sitemap');
 
-        $this->writeLocation($xmlWriter, $sitemap->getLocation());
-        $this->writeLastModified($xmlWriter, $sitemap->getLastModified());
+        $this->writeLocation($xmlWriter, $sitemap->location());
+        $this->writeLastModified($xmlWriter, $sitemap->lastModified());
 
         $xmlWriter->endElement();
     }

--- a/src/Writer/UrlSetWriter.php
+++ b/src/Writer/UrlSetWriter.php
@@ -46,7 +46,7 @@ class UrlSetWriter
         $xmlWriter->startElement('urlset');
 
         $this->writeNamespaceAttributes($xmlWriter);
-        $this->writeUrls($xmlWriter, $urlSet->getUrls());
+        $this->writeUrls($xmlWriter, $urlSet->urls());
 
         $xmlWriter->endElement();
 

--- a/src/Writer/UrlWriter.php
+++ b/src/Writer/UrlWriter.php
@@ -54,13 +54,13 @@ class UrlWriter
     {
         $xmlWriter->startElement('url');
 
-        $this->writeLocation($xmlWriter, $url->getLocation());
-        $this->writeLastModified($xmlWriter, $url->getLastModified());
-        $this->writeChangeFrequency($xmlWriter, $url->getChangeFrequency());
-        $this->writePriority($xmlWriter, $url->getPriority());
-        $this->writeImages($xmlWriter, $url->getImages());
-        $this->writeNews($xmlWriter, $url->getNews());
-        $this->writeVideos($xmlWriter, $url->getVideos());
+        $this->writeLocation($xmlWriter, $url->location());
+        $this->writeLastModified($xmlWriter, $url->lastModified());
+        $this->writeChangeFrequency($xmlWriter, $url->changeFrequency());
+        $this->writePriority($xmlWriter, $url->priority());
+        $this->writeImages($xmlWriter, $url->images());
+        $this->writeNews($xmlWriter, $url->news());
+        $this->writeVideos($xmlWriter, $url->videos());
 
         $xmlWriter->endElement();
     }

--- a/src/Writer/Video/GalleryLocationWriter.php
+++ b/src/Writer/Video/GalleryLocationWriter.php
@@ -22,11 +22,11 @@ class GalleryLocationWriter
     {
         $xmlWriter->startElement('video:gallery_loc');
 
-        if ($galleryLocation->getTitle()) {
-            $xmlWriter->writeAttribute('title', $galleryLocation->getTitle());
+        if ($galleryLocation->title()) {
+            $xmlWriter->writeAttribute('title', $galleryLocation->title());
         }
 
-        $xmlWriter->text($galleryLocation->getLocation());
+        $xmlWriter->text($galleryLocation->location());
         $xmlWriter->endElement();
     }
 }

--- a/src/Writer/Video/PlatformWriter.php
+++ b/src/Writer/Video/PlatformWriter.php
@@ -21,8 +21,8 @@ class PlatformWriter
     public function write(PlatformInterface $platform, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('video:platform');
-        $xmlWriter->writeAttribute('relationship', $platform->getRelationship());
-        $xmlWriter->text(implode(' ', $platform->getTypes()));
+        $xmlWriter->writeAttribute('relationship', $platform->relationship());
+        $xmlWriter->text(implode(' ', $platform->types()));
         $xmlWriter->endElement();
     }
 }

--- a/src/Writer/Video/PlayerLocationWriter.php
+++ b/src/Writer/Video/PlayerLocationWriter.php
@@ -22,15 +22,15 @@ class PlayerLocationWriter
     {
         $xmlWriter->startElement('video:player_loc');
 
-        if ($playerLocation->getAllowEmbed()) {
-            $xmlWriter->writeAttribute('allow_embed', $playerLocation->getAllowEmbed());
+        if ($playerLocation->allowEmbed()) {
+            $xmlWriter->writeAttribute('allow_embed', $playerLocation->allowEmbed());
         }
 
-        if ($playerLocation->getAutoPlay()) {
-            $xmlWriter->writeAttribute('autoplay', $playerLocation->getAutoPlay());
+        if ($playerLocation->autoPlay()) {
+            $xmlWriter->writeAttribute('autoplay', $playerLocation->autoPlay());
         }
 
-        $xmlWriter->text($playerLocation->getLocation());
+        $xmlWriter->text($playerLocation->location());
         $xmlWriter->endElement();
     }
 }

--- a/src/Writer/Video/PriceWriter.php
+++ b/src/Writer/Video/PriceWriter.php
@@ -21,17 +21,17 @@ class PriceWriter
     public function write(PriceInterface $price, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('video:price');
-        $xmlWriter->writeAttribute('currency', $price->getCurrency());
+        $xmlWriter->writeAttribute('currency', $price->currency());
 
-        if ($price->getType()) {
-            $xmlWriter->writeAttribute('type', $price->getType());
+        if ($price->type()) {
+            $xmlWriter->writeAttribute('type', $price->type());
         }
 
-        if ($price->getResolution()) {
-            $xmlWriter->writeAttribute('resolution', $price->getResolution());
+        if ($price->resolution()) {
+            $xmlWriter->writeAttribute('resolution', $price->resolution());
         }
 
-        $xmlWriter->text(number_format($price->getValue(), 2));
+        $xmlWriter->text(number_format($price->value(), 2));
         $xmlWriter->endElement();
     }
 }

--- a/src/Writer/Video/RestrictionWriter.php
+++ b/src/Writer/Video/RestrictionWriter.php
@@ -21,8 +21,8 @@ class RestrictionWriter
     public function write(RestrictionInterface $restriction, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('video:restriction');
-        $xmlWriter->writeAttribute('relationship', $restriction->getRelationship());
-        $xmlWriter->text(implode(' ', $restriction->getCountryCodes()));
+        $xmlWriter->writeAttribute('relationship', $restriction->relationship());
+        $xmlWriter->text(implode(' ', $restriction->countryCodes()));
         $xmlWriter->endElement();
     }
 }

--- a/src/Writer/Video/TagWriter.php
+++ b/src/Writer/Video/TagWriter.php
@@ -21,7 +21,7 @@ class TagWriter
     public function write(TagInterface $tag, XMLWriter $xmlWriter)
     {
         $xmlWriter->startElement('video:tag');
-        $xmlWriter->text($tag->getContent());
+        $xmlWriter->text($tag->content());
         $xmlWriter->endElement();
     }
 }

--- a/src/Writer/Video/UploaderWriter.php
+++ b/src/Writer/Video/UploaderWriter.php
@@ -22,11 +22,11 @@ class UploaderWriter
     {
         $xmlWriter->startElement('video:uploader');
 
-        if ($uploader->getInfo() !== null) {
-            $xmlWriter->writeAttribute('info', $uploader->getInfo());
+        if ($uploader->info() !== null) {
+            $xmlWriter->writeAttribute('info', $uploader->info());
         }
 
-        $xmlWriter->text($uploader->getName());
+        $xmlWriter->text($uploader->name());
 
         $xmlWriter->endElement();
     }

--- a/src/Writer/Video/VideoWriter.php
+++ b/src/Writer/Video/VideoWriter.php
@@ -83,26 +83,26 @@ class VideoWriter
     {
         $xmlWriter->startElement('video:video');
 
-        $this->writeThumbnailLocation($xmlWriter, $video->getThumbnailLocation());
-        $this->writeTitle($xmlWriter, $video->getTitle());
-        $this->writeDescription($xmlWriter, $video->getDescription());
-        $this->writeContentLocation($xmlWriter, $video->getContentLocation());
-        $this->writePlayerLocation($xmlWriter, $video->getPlayerLocation());
-        $this->writeGalleryLocation($xmlWriter, $video->getGalleryLocation());
-        $this->writeDuration($xmlWriter, $video->getDuration());
-        $this->writePublicationDate($xmlWriter, $video->getPublicationDate());
-        $this->writeExpirationDate($xmlWriter, $video->getExpirationDate());
-        $this->writeRating($xmlWriter, $video->getRating());
-        $this->writeViewCount($xmlWriter, $video->getViewCount());
-        $this->writeFamilyFriendly($xmlWriter, $video->getFamilyFriendly());
-        $this->writeTags($xmlWriter, $video->getTags());
-        $this->writeCategory($xmlWriter, $video->getCategory());
-        $this->writeRestriction($xmlWriter, $video->getRestriction());
-        $this->writePrices($xmlWriter, $video->getPrices());
-        $this->writeRequiresSubscription($xmlWriter, $video->getRequiresSubscription());
-        $this->writeUploader($xmlWriter, $video->getUploader());
-        $this->writePlatform($xmlWriter, $video->getPlatform());
-        $this->writeLive($xmlWriter, $video->getLive());
+        $this->writeThumbnailLocation($xmlWriter, $video->thumbnailLocation());
+        $this->writeTitle($xmlWriter, $video->title());
+        $this->writeDescription($xmlWriter, $video->description());
+        $this->writeContentLocation($xmlWriter, $video->contentLocation());
+        $this->writePlayerLocation($xmlWriter, $video->playerLocation());
+        $this->writeGalleryLocation($xmlWriter, $video->galleryLocation());
+        $this->writeDuration($xmlWriter, $video->duration());
+        $this->writePublicationDate($xmlWriter, $video->publicationDate());
+        $this->writeExpirationDate($xmlWriter, $video->expirationDate());
+        $this->writeRating($xmlWriter, $video->rating());
+        $this->writeViewCount($xmlWriter, $video->viewCount());
+        $this->writeFamilyFriendly($xmlWriter, $video->familyFriendly());
+        $this->writeTags($xmlWriter, $video->tags());
+        $this->writeCategory($xmlWriter, $video->category());
+        $this->writeRestriction($xmlWriter, $video->restriction());
+        $this->writePrices($xmlWriter, $video->prices());
+        $this->writeRequiresSubscription($xmlWriter, $video->requiresSubscription());
+        $this->writeUploader($xmlWriter, $video->uploader());
+        $this->writePlatform($xmlWriter, $video->platform());
+        $this->writeLive($xmlWriter, $video->live());
 
         $xmlWriter->endElement();
     }

--- a/test/Unit/Component/Image/ImageTest.php
+++ b/test/Unit/Component/Image/ImageTest.php
@@ -49,11 +49,11 @@ class ImageTest extends \PHPUnit_Framework_TestCase
             $licence
         );
 
-        $this->assertSame($location, $image->getLocation());
-        $this->assertSame($title, $image->getTitle());
-        $this->assertSame($caption, $image->getCaption());
-        $this->assertSame($geoLocation, $image->getGeoLocation());
-        $this->assertSame($licence, $image->getLicence());
+        $this->assertSame($location, $image->location());
+        $this->assertSame($title, $image->title());
+        $this->assertSame($caption, $image->caption());
+        $this->assertSame($geoLocation, $image->geoLocation());
+        $this->assertSame($licence, $image->licence());
     }
 
     public function testDefaults()
@@ -62,9 +62,9 @@ class ImageTest extends \PHPUnit_Framework_TestCase
 
         $image = new Image($location);
 
-        $this->assertNull($image->getTitle());
-        $this->assertNull($image->getCaption());
-        $this->assertNull($image->getGeoLocation());
-        $this->assertNull($image->getLicence());
+        $this->assertNull($image->title());
+        $this->assertNull($image->caption());
+        $this->assertNull($image->geoLocation());
+        $this->assertNull($image->licence());
     }
 }

--- a/test/Unit/Component/News/NewsTest.php
+++ b/test/Unit/Component/News/NewsTest.php
@@ -64,14 +64,14 @@ class NewsTest extends \PHPUnit_Framework_TestCase
             $stockTickers
         );
 
-        $this->assertSame($publication, $news->getPublication());
-        $this->assertEquals($publicationDate, $news->getPublicationDate());
-        $this->assertNotSame($publicationDate, $news->getPublicationDate());
-        $this->assertSame($title, $news->getTitle());
-        $this->assertSame($access, $news->getAccess());
-        $this->assertSame($genres, $news->getGenres());
-        $this->assertSame($keywords, $news->getKeywords());
-        $this->assertSame($stockTickers, $news->getStockTickers());
+        $this->assertSame($publication, $news->publication());
+        $this->assertEquals($publicationDate, $news->publicationDate());
+        $this->assertNotSame($publicationDate, $news->publicationDate());
+        $this->assertSame($title, $news->title());
+        $this->assertSame($access, $news->access());
+        $this->assertSame($genres, $news->genres());
+        $this->assertSame($keywords, $news->keywords());
+        $this->assertSame($stockTickers, $news->stockTickers());
     }
 
     public function testDefaults()
@@ -84,16 +84,16 @@ class NewsTest extends \PHPUnit_Framework_TestCase
             $faker->sentence()
         );
 
-        $this->assertNull($news->getAccess());
+        $this->assertNull($news->access());
 
-        $this->assertInternalType('array', $news->getGenres());
-        $this->assertCount(0, $news->getGenres());
+        $this->assertInternalType('array', $news->genres());
+        $this->assertCount(0, $news->genres());
 
-        $this->assertInternalType('array', $news->getKeywords());
-        $this->assertCount(0, $news->getKeywords());
+        $this->assertInternalType('array', $news->keywords());
+        $this->assertCount(0, $news->keywords());
 
-        $this->assertInternalType('array', $news->getStockTickers());
-        $this->assertCount(0, $news->getStockTickers());
+        $this->assertInternalType('array', $news->stockTickers());
+        $this->assertCount(0, $news->stockTickers());
     }
 
     /**
@@ -112,7 +112,7 @@ class NewsTest extends \PHPUnit_Framework_TestCase
             $access
         );
 
-        $this->assertSame($access, $news->getAccess());
+        $this->assertSame($access, $news->access());
     }
 
     /**
@@ -167,7 +167,7 @@ class NewsTest extends \PHPUnit_Framework_TestCase
             $genres
         );
 
-        $this->assertSame($genres, $news->getGenres());
+        $this->assertSame($genres, $news->genres());
     }
 
     /**

--- a/test/Unit/Component/News/PublicationTest.php
+++ b/test/Unit/Component/News/PublicationTest.php
@@ -43,7 +43,7 @@ class PublicationTest extends \PHPUnit_Framework_TestCase
             $language
         );
 
-        $this->assertSame($name, $publication->getName());
-        $this->assertSame($language, $publication->getLanguage());
+        $this->assertSame($name, $publication->name());
+        $this->assertSame($language, $publication->language());
     }
 }

--- a/test/Unit/Component/SitemapIndexTest.php
+++ b/test/Unit/Component/SitemapIndexTest.php
@@ -29,8 +29,8 @@ class SitemapIndexTest extends \PHPUnit_Framework_TestCase
     {
         $index = new SitemapIndex();
 
-        $this->assertInternalType('array', $index->getSitemaps());
-        $this->assertCount(0, $index->getSitemaps());
+        $this->assertInternalType('array', $index->sitemaps());
+        $this->assertCount(0, $index->sitemaps());
     }
 
     public function testCanAddSitemap()
@@ -40,9 +40,9 @@ class SitemapIndexTest extends \PHPUnit_Framework_TestCase
         $index = new SitemapIndex();
         $index->addSitemap($sitemap);
 
-        $this->assertInternalType('array', $index->getSitemaps());
-        $this->assertCount(1, $index->getSitemaps());
-        $this->assertSame($sitemap, $index->getSitemaps()[0]);
+        $this->assertInternalType('array', $index->sitemaps());
+        $this->assertCount(1, $index->sitemaps());
+        $this->assertSame($sitemap, $index->sitemaps()[0]);
     }
 
     public function testCanNotAddTwoSitemapsWithSameLocation()

--- a/test/Unit/Component/SitemapTest.php
+++ b/test/Unit/Component/SitemapTest.php
@@ -43,9 +43,9 @@ class SitemapTest extends \PHPUnit_Framework_TestCase
             $lastModified
         );
 
-        $this->assertSame($location, $sitemap->getLocation());
-        $this->assertEquals($lastModified, $sitemap->getLastModified());
-        $this->assertNotSame($lastModified, $sitemap->getLastModified());
+        $this->assertSame($location, $sitemap->location());
+        $this->assertEquals($lastModified, $sitemap->lastModified());
+        $this->assertNotSame($lastModified, $sitemap->lastModified());
     }
 
     public function testDefaults()
@@ -54,7 +54,7 @@ class SitemapTest extends \PHPUnit_Framework_TestCase
 
         $sitemap = new Sitemap($location);
 
-        $this->assertSame($location, $sitemap->getLocation());
-        $this->assertNull($sitemap->getLastModified());
+        $this->assertSame($location, $sitemap->location());
+        $this->assertNull($sitemap->lastModified());
     }
 }

--- a/test/Unit/Component/UrlSetTest.php
+++ b/test/Unit/Component/UrlSetTest.php
@@ -30,8 +30,8 @@ class UrlSetTest extends \PHPUnit_Framework_TestCase
     {
         $urlSet = new UrlSet();
 
-        $this->assertInternalType('array', $urlSet->getUrls());
-        $this->assertCount(0, $urlSet->getUrls());
+        $this->assertInternalType('array', $urlSet->urls());
+        $this->assertCount(0, $urlSet->urls());
     }
 
     public function testCanAddUrl()
@@ -41,9 +41,9 @@ class UrlSetTest extends \PHPUnit_Framework_TestCase
         $urlSet = new UrlSet();
         $urlSet->addUrl($url);
 
-        $this->assertInternalType('array', $urlSet->getUrls());
-        $this->assertCount(1, $urlSet->getUrls());
-        $this->assertSame($url, $urlSet->getUrls()[0]);
+        $this->assertInternalType('array', $urlSet->urls());
+        $this->assertCount(1, $urlSet->urls());
+        $this->assertSame($url, $urlSet->urls()[0]);
     }
 
     public function testCanAddALotOfUrls()
@@ -65,9 +65,9 @@ class UrlSetTest extends \PHPUnit_Framework_TestCase
 
         $urlSet->addUrl($url);
 
-        $this->assertInternalType('array', $urlSet->getUrls());
-        $this->assertCount(UrlSetInterface::URL_MAX_COUNT, $urlSet->getUrls());
-        $this->assertContains($url, $urlSet->getUrls());
+        $this->assertInternalType('array', $urlSet->urls());
+        $this->assertCount(UrlSetInterface::URL_MAX_COUNT, $urlSet->urls());
+        $this->assertContains($url, $urlSet->urls());
     }
 
     public function testCanNotAddMoreUrlMaxCountUrls()

--- a/test/Unit/Component/UrlTest.php
+++ b/test/Unit/Component/UrlTest.php
@@ -43,11 +43,11 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             $priority
         );
 
-        $this->assertSame($location, $url->getLocation());
-        $this->assertEquals($lastModified, $url->getLastModified());
-        $this->assertNotSame($lastModified, $url->getLastModified());
-        $this->assertSame($changeFrequency, $url->getChangeFrequency());
-        $this->assertSame($priority, $url->getPriority());
+        $this->assertSame($location, $url->location());
+        $this->assertEquals($lastModified, $url->lastModified());
+        $this->assertNotSame($lastModified, $url->lastModified());
+        $this->assertSame($changeFrequency, $url->changeFrequency());
+        $this->assertSame($priority, $url->priority());
     }
 
     public function testDefaults()
@@ -56,16 +56,16 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
         $url = new Url($location);
 
-        $this->assertSame($location, $url->getLocation());
-        $this->assertNull($url->getLastModified());
-        $this->assertNull($url->getChangeFrequency());
-        $this->assertNull($url->getPriority());
-        $this->assertInternalType('array', $url->getImages());
-        $this->assertCount(0, $url->getImages());
-        $this->assertInternalType('array', $url->getNews());
-        $this->assertCount(0, $url->getNews());
-        $this->assertInternalType('array', $url->getVideos());
-        $this->assertCount(0, $url->getVideos());
+        $this->assertSame($location, $url->location());
+        $this->assertNull($url->lastModified());
+        $this->assertNull($url->changeFrequency());
+        $this->assertNull($url->priority());
+        $this->assertInternalType('array', $url->images());
+        $this->assertCount(0, $url->images());
+        $this->assertInternalType('array', $url->news());
+        $this->assertCount(0, $url->news());
+        $this->assertInternalType('array', $url->videos());
+        $this->assertCount(0, $url->videos());
     }
 
     public function testCanAddImages()
@@ -76,9 +76,9 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
         $url->addImage($image);
 
-        $this->assertInternalType('array', $url->getImages());
-        $this->assertCount(1, $url->getImages());
-        $this->assertSame($image, $url->getImages()[0]);
+        $this->assertInternalType('array', $url->images());
+        $this->assertCount(1, $url->images());
+        $this->assertSame($image, $url->images()[0]);
     }
 
     public function testCanNotAddMoreThanMaximumNumberOfImages()
@@ -105,9 +105,9 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
         $url->addNews($news);
 
-        $this->assertInternalType('array', $url->getNews());
-        $this->assertCount(1, $url->getNews());
-        $this->assertSame($news, $url->getNews()[0]);
+        $this->assertInternalType('array', $url->news());
+        $this->assertCount(1, $url->news());
+        $this->assertSame($news, $url->news()[0]);
     }
 
     public function testCanAddVideos()
@@ -118,9 +118,9 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
         $url->addVideo($video);
 
-        $this->assertInternalType('array', $url->getVideos());
-        $this->assertCount(1, $url->getVideos());
-        $this->assertSame($video, $url->getVideos()[0]);
+        $this->assertInternalType('array', $url->videos());
+        $this->assertCount(1, $url->videos());
+        $this->assertSame($video, $url->videos()[0]);
     }
 
     /**

--- a/test/Unit/Component/Video/GalleryLocationTest.php
+++ b/test/Unit/Component/Video/GalleryLocationTest.php
@@ -43,14 +43,14 @@ class GalleryLocationTest extends \PHPUnit_Framework_TestCase
             $title
         );
 
-        $this->assertSame($location, $galleryLocation->getLocation());
-        $this->assertSame($title, $galleryLocation->getTitle());
+        $this->assertSame($location, $galleryLocation->location());
+        $this->assertSame($title, $galleryLocation->title());
     }
 
     public function testDefaults()
     {
         $galleryLocation = new GalleryLocation($this->getFaker()->url);
 
-        $this->assertNull($galleryLocation->getTitle());
+        $this->assertNull($galleryLocation->title());
     }
 }

--- a/test/Unit/Component/Video/PlatformTest.php
+++ b/test/Unit/Component/Video/PlatformTest.php
@@ -43,7 +43,7 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
 
         $platform = new Platform($relationship);
 
-        $this->assertSame($relationship, $platform->getRelationship());
+        $this->assertSame($relationship, $platform->relationship());
     }
 
     public function testDefaults()
@@ -55,8 +55,8 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
             PlatformInterface::RELATIONSHIP_DENY,
         ]));
 
-        $this->assertInternalType('array', $platform->getTypes());
-        $this->assertCount(0, $platform->getTypes());
+        $this->assertInternalType('array', $platform->types());
+        $this->assertCount(0, $platform->types());
     }
 
     public function testInvalidRelationshipIsRejected()
@@ -83,9 +83,9 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
 
         $platform->addType($type);
 
-        $this->assertInternalType('array', $platform->getTypes());
-        $this->assertCount(1, $platform->getTypes());
-        $this->assertSame($type, $platform->getTypes()[0]);
+        $this->assertInternalType('array', $platform->types());
+        $this->assertCount(1, $platform->types());
+        $this->assertSame($type, $platform->types()[0]);
     }
 
     public function testCanNotAddSameTypeTwice()

--- a/test/Unit/Component/Video/PlayerLocationTest.php
+++ b/test/Unit/Component/Video/PlayerLocationTest.php
@@ -55,17 +55,17 @@ class PlayerLocationTest extends \PHPUnit_Framework_TestCase
             $autoPlay
         );
 
-        $this->assertSame($location, $playerLocation->getLocation());
-        $this->assertSame($allowEmbed, $playerLocation->getAllowEmbed());
-        $this->assertSame($autoPlay, $playerLocation->getAutoPlay());
+        $this->assertSame($location, $playerLocation->location());
+        $this->assertSame($allowEmbed, $playerLocation->allowEmbed());
+        $this->assertSame($autoPlay, $playerLocation->autoPlay());
     }
 
     public function testDefaults()
     {
         $playerLocation = new PlayerLocation($this->getFaker()->url);
 
-        $this->assertNull($playerLocation->getAllowEmbed());
-        $this->assertNull($playerLocation->getAutoPlay());
+        $this->assertNull($playerLocation->allowEmbed());
+        $this->assertNull($playerLocation->autoPlay());
     }
 
     public function testInvalidAllowEmbedIsRejected()

--- a/test/Unit/Component/Video/PriceTest.php
+++ b/test/Unit/Component/Video/PriceTest.php
@@ -63,10 +63,10 @@ class PriceTest extends \PHPUnit_Framework_TestCase
             $resolution
         );
 
-        $this->assertSame($value, $price->getValue());
-        $this->assertSame($currency, $price->getCurrency());
-        $this->assertSame($type, $price->getType());
-        $this->assertSame($resolution, $price->getResolution());
+        $this->assertSame($value, $price->value());
+        $this->assertSame($currency, $price->currency());
+        $this->assertSame($type, $price->type());
+        $this->assertSame($resolution, $price->resolution());
     }
 
     public function testDefaults()
@@ -78,8 +78,8 @@ class PriceTest extends \PHPUnit_Framework_TestCase
             $faker->currencyCode
         );
 
-        $this->assertNull($price->getType());
-        $this->assertNull($price->getResolution());
+        $this->assertNull($price->type());
+        $this->assertNull($price->resolution());
     }
 
     public function testInvalidTypeIsRejected()

--- a/test/Unit/Component/Video/RestrictionTest.php
+++ b/test/Unit/Component/Video/RestrictionTest.php
@@ -41,7 +41,7 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
 
         $restriction = new Restriction($relationship);
 
-        $this->assertSame($relationship, $restriction->getRelationship());
+        $this->assertSame($relationship, $restriction->relationship());
     }
 
     public function testDefaults()
@@ -53,8 +53,8 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
 
         $restriction = new Restriction($relationship);
 
-        $this->assertInternalType('array', $restriction->getCountryCodes());
-        $this->assertCount(0, $restriction->getCountryCodes());
+        $this->assertInternalType('array', $restriction->countryCodes());
+        $this->assertCount(0, $restriction->countryCodes());
     }
 
     public function testInvalidRestrictionIsRejected()
@@ -84,6 +84,6 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
             $restriction->addCountryCode($countryCode);
         }
 
-        $this->assertSame($countryCodes, $restriction->getCountryCodes());
+        $this->assertSame($countryCodes, $restriction->countryCodes());
     }
 }

--- a/test/Unit/Component/Video/TagTest.php
+++ b/test/Unit/Component/Video/TagTest.php
@@ -37,6 +37,6 @@ class TagTest extends \PHPUnit_Framework_TestCase
 
         $tag = new Tag($content);
 
-        $this->assertSame($content, $tag->getContent());
+        $this->assertSame($content, $tag->content());
     }
 }

--- a/test/Unit/Component/Video/UploaderTest.php
+++ b/test/Unit/Component/Video/UploaderTest.php
@@ -43,14 +43,14 @@ class UploaderTest extends \PHPUnit_Framework_TestCase
             $info
         );
 
-        $this->assertSame($name, $videoUploader->getName());
-        $this->assertSame($info, $videoUploader->getInfo());
+        $this->assertSame($name, $videoUploader->name());
+        $this->assertSame($info, $videoUploader->info());
     }
 
     public function testDefaults()
     {
         $videoUploader = new Uploader($this->getFaker()->name);
 
-        $this->assertNull($videoUploader->getInfo());
+        $this->assertNull($videoUploader->info());
     }
 }

--- a/test/Unit/Component/Video/VideoTest.php
+++ b/test/Unit/Component/Video/VideoTest.php
@@ -92,26 +92,26 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             $live
         );
 
-        $this->assertSame($thumbnailLocation, $video->getThumbnailLocation());
-        $this->assertSame($title, $video->getTitle());
-        $this->assertSame($description, $video->getDescription());
-        $this->assertSame($contentLocation, $video->getContentLocation());
-        $this->assertSame($playerLocation, $video->getPlayerLocation());
-        $this->assertSame($galleryLocation, $video->getGalleryLocation());
-        $this->assertSame($duration, $video->getDuration());
-        $this->assertEquals($publicationDate, $video->getPublicationDate());
-        $this->assertNotSame($publicationDate, $video->getPublicationDate());
-        $this->assertEquals($expirationDate, $video->getExpirationDate());
-        $this->assertNotSame($expirationDate, $video->getExpirationDate());
-        $this->assertSame($rating, $video->getRating());
-        $this->assertSame($viewCount, $video->getViewCount());
-        $this->assertSame($familyFriendly, $video->getFamilyFriendly());
-        $this->assertSame($category, $video->getCategory());
-        $this->assertSame($restriction, $video->getRestriction());
-        $this->assertSame($requiresSubscription, $video->getRequiresSubscription());
-        $this->assertSame($uploader, $video->getUploader());
-        $this->assertSame($platform, $video->getPlatform());
-        $this->assertSame($live, $video->getLive());
+        $this->assertSame($thumbnailLocation, $video->thumbnailLocation());
+        $this->assertSame($title, $video->title());
+        $this->assertSame($description, $video->description());
+        $this->assertSame($contentLocation, $video->contentLocation());
+        $this->assertSame($playerLocation, $video->playerLocation());
+        $this->assertSame($galleryLocation, $video->galleryLocation());
+        $this->assertSame($duration, $video->duration());
+        $this->assertEquals($publicationDate, $video->publicationDate());
+        $this->assertNotSame($publicationDate, $video->publicationDate());
+        $this->assertEquals($expirationDate, $video->expirationDate());
+        $this->assertNotSame($expirationDate, $video->expirationDate());
+        $this->assertSame($rating, $video->rating());
+        $this->assertSame($viewCount, $video->viewCount());
+        $this->assertSame($familyFriendly, $video->familyFriendly());
+        $this->assertSame($category, $video->category());
+        $this->assertSame($restriction, $video->restriction());
+        $this->assertSame($requiresSubscription, $video->requiresSubscription());
+        $this->assertSame($uploader, $video->uploader());
+        $this->assertSame($platform, $video->platform());
+        $this->assertSame($live, $video->live());
     }
 
     public function testDefaults()
@@ -125,23 +125,23 @@ class VideoTest extends \PHPUnit_Framework_TestCase
             $faker->url
         );
 
-        $this->assertNull($video->getPlayerLocation());
-        $this->assertNull($video->getGalleryLocation());
-        $this->assertNull($video->getDuration());
-        $this->assertNull($video->getPublicationDate());
-        $this->assertNull($video->getExpirationDate());
-        $this->assertNull($video->getRating());
-        $this->assertNull($video->getViewCount());
-        $this->assertNull($video->getFamilyFriendly());
-        $this->assertInternalType('array', $video->getTags());
-        $this->assertCount(0, $video->getTags());
-        $this->assertNull($video->getCategory());
-        $this->assertNull($video->getRestriction());
-        $this->assertInternalType('array', $video->getPrices());
-        $this->assertCount(0, $video->getPrices());
-        $this->assertNull($video->getRequiresSubscription());
-        $this->assertNull($video->getUploader());
-        $this->assertNull($video->getPlatform());
+        $this->assertNull($video->playerLocation());
+        $this->assertNull($video->galleryLocation());
+        $this->assertNull($video->duration());
+        $this->assertNull($video->publicationDate());
+        $this->assertNull($video->expirationDate());
+        $this->assertNull($video->rating());
+        $this->assertNull($video->viewCount());
+        $this->assertNull($video->familyFriendly());
+        $this->assertInternalType('array', $video->tags());
+        $this->assertCount(0, $video->tags());
+        $this->assertNull($video->category());
+        $this->assertNull($video->restriction());
+        $this->assertInternalType('array', $video->prices());
+        $this->assertCount(0, $video->prices());
+        $this->assertNull($video->requiresSubscription());
+        $this->assertNull($video->uploader());
+        $this->assertNull($video->platform());
     }
 
     public function testTitleLongerThanMaxLengthIsRejected()
@@ -437,9 +437,9 @@ class VideoTest extends \PHPUnit_Framework_TestCase
 
         $video->addTag($tag);
 
-        $this->assertInternalType('array', $video->getTags());
-        $this->assertCount(1, $video->getTags());
-        $this->assertSame($tag, $video->getTags()[0]);
+        $this->assertInternalType('array', $video->tags());
+        $this->assertCount(1, $video->tags());
+        $this->assertSame($tag, $video->tags()[0]);
     }
 
     public function testCanNotAddMoreThanMaximumNumberOfTags()
@@ -505,9 +505,9 @@ class VideoTest extends \PHPUnit_Framework_TestCase
 
         $video->addPrice($price);
 
-        $this->assertInternalType('array', $video->getPrices());
-        $this->assertCount(1, $video->getPrices());
-        $this->assertSame($price, $video->getPrices()[0]);
+        $this->assertInternalType('array', $video->prices());
+        $this->assertCount(1, $video->prices());
+        $this->assertSame($price, $video->prices()[0]);
     }
 
     /**

--- a/test/Unit/Writer/Image/ImageWriterTest.php
+++ b/test/Unit/Writer/Image/ImageWriterTest.php
@@ -86,31 +86,31 @@ class ImageWriterTest extends AbstractTestCase
 
         $image
             ->expects($this->any())
-            ->method('getLocation')
+            ->method('location')
             ->willReturn($location)
         ;
 
         $image
             ->expects($this->any())
-            ->method('getTitle')
+            ->method('title')
             ->willReturn($title)
         ;
 
         $image
             ->expects($this->any())
-            ->method('getCaption')
+            ->method('caption')
             ->willReturn($caption)
         ;
 
         $image
             ->expects($this->any())
-            ->method('getGeoLocation')
+            ->method('geoLocation')
             ->willReturn($geoLocation)
         ;
 
         $image
             ->expects($this->any())
-            ->method('getLicence')
+            ->method('licence')
             ->willReturn($licence)
         ;
 

--- a/test/Unit/Writer/News/NewsWriterTest.php
+++ b/test/Unit/Writer/News/NewsWriterTest.php
@@ -140,43 +140,43 @@ class NewsWriterTest extends AbstractTestCase
 
         $news
             ->expects($this->any())
-            ->method('getPublication')
+            ->method('publication')
             ->willReturn($publication)
         ;
 
         $news
             ->expects($this->any())
-            ->method('getPublicationDate')
+            ->method('publicationDate')
             ->willReturn($publicationDate)
         ;
 
         $news
             ->expects($this->any())
-            ->method('getTitle')
+            ->method('title')
             ->willReturn($title)
         ;
 
         $news
             ->expects($this->any())
-            ->method('getAccess')
+            ->method('access')
             ->willReturn($access)
         ;
 
         $news
             ->expects($this->any())
-            ->method('getGenres')
+            ->method('genres')
             ->willReturn($genres)
         ;
 
         $news
             ->expects($this->any())
-            ->method('getKeywords')
+            ->method('keywords')
             ->willReturn($keywords)
         ;
 
         $news
             ->expects($this->any())
-            ->method('getStockTickers')
+            ->method('stockTickers')
             ->willReturn($stockTickers)
         ;
 

--- a/test/Unit/Writer/News/PublicationWriterTest.php
+++ b/test/Unit/Writer/News/PublicationWriterTest.php
@@ -53,13 +53,13 @@ class PublicationWriterTest extends AbstractTestCase
 
         $publication
             ->expects($this->any())
-            ->method('getName')
+            ->method('name')
             ->willReturn($name)
         ;
 
         $publication
             ->expects($this->any())
-            ->method('getLanguage')
+            ->method('language')
             ->willReturn($language)
         ;
 

--- a/test/Unit/Writer/SitemapIndexWriterTest.php
+++ b/test/Unit/Writer/SitemapIndexWriterTest.php
@@ -80,7 +80,7 @@ class SitemapIndexWriterTest extends AbstractTestCase
 
         $sitemapIndex
             ->expects($this->any())
-            ->method('getSitemaps')
+            ->method('sitemaps')
             ->willReturn($sitemaps)
         ;
 

--- a/test/Unit/Writer/SitemapWriterTest.php
+++ b/test/Unit/Writer/SitemapWriterTest.php
@@ -74,13 +74,13 @@ class SitemapWriterTest extends AbstractTestCase
 
         $sitemap
             ->expects($this->any())
-            ->method('getLocation')
+            ->method('location')
             ->willReturn($location)
         ;
 
         $sitemap
             ->expects($this->any())
-            ->method('getLastModified')
+            ->method('lastModified')
             ->willReturn($lastModified)
         ;
 

--- a/test/Unit/Writer/UrlSetWriterTest.php
+++ b/test/Unit/Writer/UrlSetWriterTest.php
@@ -90,7 +90,7 @@ class UrlSetWriterTest extends AbstractTestCase
 
         $urlSet
             ->expects($this->any())
-            ->method('getUrls')
+            ->method('urls')
             ->willReturn($urls)
         ;
 

--- a/test/Unit/Writer/UrlWriterTest.php
+++ b/test/Unit/Writer/UrlWriterTest.php
@@ -135,43 +135,43 @@ class UrlWriterTest extends AbstractTestCase
 
         $url
             ->expects($this->any())
-            ->method('getLocation')
+            ->method('location')
             ->willReturn($location)
         ;
 
         $url
             ->expects($this->any())
-            ->method('getLastModified')
+            ->method('lastModified')
             ->willReturn($lastModified)
         ;
 
         $url
             ->expects($this->any())
-            ->method('getChangeFrequency')
+            ->method('changeFrequency')
             ->willReturn($changeFrequency)
         ;
 
         $url
             ->expects($this->any())
-            ->method('getPriority')
+            ->method('priority')
             ->willReturn($priority)
         ;
 
         $url
             ->expects($this->any())
-            ->method('getImages')
+            ->method('images')
             ->willReturn($images)
         ;
 
         $url
             ->expects($this->any())
-            ->method('getNews')
+            ->method('news')
             ->willReturn($news)
         ;
 
         $url
             ->expects($this->any())
-            ->method('getVideos')
+            ->method('videos')
             ->willReturn($videos)
         ;
 

--- a/test/Unit/Writer/Video/GalleryLocationWriterTest.php
+++ b/test/Unit/Writer/Video/GalleryLocationWriterTest.php
@@ -67,13 +67,13 @@ class GalleryLocationWriterTest extends AbstractTestCase
 
         $galleryLocation
             ->expects($this->any())
-            ->method('getLocation')
+            ->method('location')
             ->willReturn($location)
         ;
 
         $galleryLocation
             ->expects($this->any())
-            ->method('getTitle')
+            ->method('title')
             ->willReturn($title)
         ;
 

--- a/test/Unit/Writer/Video/PlatformWriterTest.php
+++ b/test/Unit/Writer/Video/PlatformWriterTest.php
@@ -58,13 +58,13 @@ class PlatformWriterTest extends AbstractTestCase
 
         $platform
             ->expects($this->any())
-            ->method('getRelationship')
+            ->method('relationship')
             ->willReturn($relationship)
         ;
 
         $platform
             ->expects($this->any())
-            ->method('getTypes')
+            ->method('types')
             ->willReturn($types)
         ;
 

--- a/test/Unit/Writer/Video/PlayerLocationWriterTest.php
+++ b/test/Unit/Writer/Video/PlayerLocationWriterTest.php
@@ -74,19 +74,19 @@ class PlayerLocationWriterTest extends AbstractTestCase
 
         $playerLocation
             ->expects($this->any())
-            ->method('getLocation')
+            ->method('location')
             ->willReturn($location)
         ;
 
         $playerLocation
             ->expects($this->any())
-            ->method('getAllowEmbed')
+            ->method('allowEmbed')
             ->willReturn($allowEmbed)
         ;
 
         $playerLocation
             ->expects($this->any())
-            ->method('getAutoPlay')
+            ->method('autoPlay')
             ->willReturn($autoPlay)
         ;
 

--- a/test/Unit/Writer/Video/PriceWriterTest.php
+++ b/test/Unit/Writer/Video/PriceWriterTest.php
@@ -87,25 +87,25 @@ class PriceWriterTest extends AbstractTestCase
 
         $price
             ->expects($this->any())
-            ->method('getCurrency')
+            ->method('currency')
             ->willReturn($currency)
         ;
 
         $price
             ->expects($this->any())
-            ->method('getValue')
+            ->method('value')
             ->willReturn($value)
         ;
 
         $price
             ->expects($this->any())
-            ->method('getType')
+            ->method('type')
             ->willReturn($type)
         ;
 
         $price
             ->expects($this->any())
-            ->method('getResolution')
+            ->method('resolution')
             ->willReturn($resolution)
         ;
 

--- a/test/Unit/Writer/Video/RestrictionWriterTest.php
+++ b/test/Unit/Writer/Video/RestrictionWriterTest.php
@@ -58,13 +58,13 @@ class RestrictionWriterTest extends AbstractTestCase
 
         $restriction
             ->expects($this->any())
-            ->method('getRelationship')
+            ->method('relationship')
             ->willReturn($relationship)
         ;
 
         $restriction
             ->expects($this->any())
-            ->method('getCountryCodes')
+            ->method('countryCodes')
             ->willReturn($countryCodes)
         ;
 

--- a/test/Unit/Writer/Video/TagWriterTest.php
+++ b/test/Unit/Writer/Video/TagWriterTest.php
@@ -41,7 +41,7 @@ class TagWriterTest extends AbstractTestCase
 
         $tag
             ->expects($this->any())
-            ->method('getContent')
+            ->method('content')
             ->willReturn($content)
         ;
 

--- a/test/Unit/Writer/Video/UploaderWriterTest.php
+++ b/test/Unit/Writer/Video/UploaderWriterTest.php
@@ -65,13 +65,13 @@ class UploaderWriterTest extends AbstractTestCase
 
         $uploader
             ->expects($this->any())
-            ->method('getName')
+            ->method('name')
             ->willReturn($name)
         ;
 
         $uploader
             ->expects($this->any())
-            ->method('getInfo')
+            ->method('info')
             ->willReturn($info)
         ;
 

--- a/test/Unit/Writer/Video/VideoWriterTest.php
+++ b/test/Unit/Writer/Video/VideoWriterTest.php
@@ -238,121 +238,121 @@ class VideoWriterTest extends AbstractTestCase
 
         $video
             ->expects($this->any())
-            ->method('getThumbnailLocation')
+            ->method('thumbnailLocation')
             ->willReturn($thumbnailLocation)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getTitle')
+            ->method('title')
             ->willReturn($title)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getDescription')
+            ->method('description')
             ->willReturn($description)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getContentLocation')
+            ->method('contentLocation')
             ->willReturn($contentLocation)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getPlayerLocation')
+            ->method('playerLocation')
             ->willReturn($playerLocation)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getGalleryLocation')
+            ->method('galleryLocation')
             ->willReturn($galleryLocation)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getDuration')
+            ->method('duration')
             ->willReturn($duration)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getPublicationDate')
+            ->method('publicationDate')
             ->willReturn($publicationDate)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getExpirationDate')
+            ->method('expirationDate')
             ->willReturn($expirationDate)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getRating')
+            ->method('rating')
             ->willReturn($rating)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getViewCount')
+            ->method('viewCount')
             ->willReturn($viewCount)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getFamilyFriendly')
+            ->method('familyFriendly')
             ->willReturn($familyFriendly)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getCategory')
+            ->method('category')
             ->willReturn($category)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getRestriction')
+            ->method('restriction')
             ->willReturn($restriction)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getRequiresSubscription')
+            ->method('requiresSubscription')
             ->willReturn($requiresSubscription)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getUploader')
+            ->method('uploader')
             ->willReturn($uploader)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getPlatform')
+            ->method('platform')
             ->willReturn($platform)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getLive')
+            ->method('live')
             ->willReturn($live)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getPrices')
+            ->method('prices')
             ->willReturn($prices)
         ;
 
         $video
             ->expects($this->any())
-            ->method('getTags')
+            ->method('tags')
             ->willReturn($tags)
         ;
 


### PR DESCRIPTION
This PR

* [x] drops the `get` prefix from accessors  

:information_desk_person: This is part of a series turning the components into immutable objects.