### PR TITLE
Fix: Turn GalleryLocation into immutable object

### DIFF
--- a/src/Component/Video/GalleryLocation.php
+++ b/src/Component/Video/GalleryLocation.php
@@ -21,13 +21,11 @@ final class GalleryLocation implements GalleryLocationInterface
     private $title;
 
     /**
-     * @param string      $location
-     * @param string|null $title
+     * @param string $location
      */
-    public function __construct($location, $title = null)
+    public function __construct($location)
     {
         $this->location = $location;
-        $this->title = $title;
     }
 
     public function location()
@@ -38,5 +36,19 @@ final class GalleryLocation implements GalleryLocationInterface
     public function title()
     {
         return $this->title;
+    }
+
+    /**
+     * @param string $title
+     *
+     * @return static
+     */
+    public function withTitle($title)
+    {
+        $instance = clone $this;
+
+        $instance->title = $title;
+
+        return $instance;
     }
 }

--- a/test/Unit/Component/Video/GalleryLocationTest.php
+++ b/test/Unit/Component/Video/GalleryLocationTest.php
@@ -31,26 +31,36 @@ class GalleryLocationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->implementsInterface(GalleryLocationInterface::class));
     }
 
-    public function testConstructorSetsValues()
-    {
-        $faker = $this->getFaker();
-
-        $location = $faker->url;
-        $title = $faker->sentence;
-
-        $galleryLocation = new GalleryLocation(
-            $location,
-            $title
-        );
-
-        $this->assertSame($location, $galleryLocation->location());
-        $this->assertSame($title, $galleryLocation->title());
-    }
-
     public function testDefaults()
     {
         $galleryLocation = new GalleryLocation($this->getFaker()->url);
 
         $this->assertNull($galleryLocation->title());
+    }
+
+    public function testConstructorSetsValue()
+    {
+        $faker = $this->getFaker();
+
+        $location = $faker->url;
+
+        $galleryLocation = new GalleryLocation($location);
+
+        $this->assertSame($location, $galleryLocation->location());
+    }
+
+    public function testWithTitleClonesObjectAndSetsValue()
+    {
+        $faker = $this->getFaker();
+
+        $title = $faker->sentence;
+
+        $galleryLocation = new GalleryLocation($faker->url);
+
+        $instance = $galleryLocation->withTitle($title);
+
+        $this->assertInstanceOf(GalleryLocation::class, $instance);
+        $this->assertNotSame($galleryLocation, $instance);
+        $this->assertSame($title, $instance->title());
     }
 }


### PR DESCRIPTION
This PR

* [x] turns `GalleryLocation` into an immutable object  

Follows #56.

