### PR TITLE
Fix: Turn PlayerLocation into an immutable object

### DIFF
--- a/src/Component/Video/PlayerLocation.php
+++ b/src/Component/Video/PlayerLocation.php
@@ -28,37 +28,16 @@ final class PlayerLocation implements PlayerLocationInterface
     private $autoPlay;
 
     /**
-     * @param string      $location
-     * @param string|null $allowEmbed
-     * @param string|null $autoPlay
+     * @param string $location
      */
-    public function __construct($location, $allowEmbed = null, $autoPlay = null)
+    public function __construct($location)
     {
         $this->location = $location;
-
-        $this->setAllowEmbed($allowEmbed);
-
-        $this->autoPlay = $autoPlay;
     }
 
     public function location()
     {
         return $this->location;
-    }
-
-    /**
-     * @param string|null $allowEmbed
-     */
-    private function setAllowEmbed($allowEmbed = null)
-    {
-        $choices = [
-            PlayerLocationInterface::ALLOW_EMBED_NO,
-            PlayerLocationInterface::ALLOW_EMBED_YES,
-        ];
-
-        Assertion::nullOrChoice($allowEmbed, $choices);
-
-        $this->allowEmbed = $allowEmbed;
     }
 
     public function allowEmbed()
@@ -69,5 +48,40 @@ final class PlayerLocation implements PlayerLocationInterface
     public function autoPlay()
     {
         return $this->autoPlay;
+    }
+
+    /**
+     * @param string $allowEmbed
+     *
+     * @return static
+     */
+    public function withAllowEmbed($allowEmbed)
+    {
+        $choices = [
+            PlayerLocationInterface::ALLOW_EMBED_NO,
+            PlayerLocationInterface::ALLOW_EMBED_YES,
+        ];
+
+        Assertion::nullOrChoice($allowEmbed, $choices);
+
+        $instance = clone $this;
+
+        $instance->allowEmbed = $allowEmbed;
+
+        return $instance;
+    }
+
+    /**
+     * @param string $autoPlay
+     *
+     * @return static
+     */
+    public function withAutoPlay($autoPlay)
+    {
+        $instance = clone $this;
+
+        $instance->autoPlay = $autoPlay;
+
+        return $instance;
     }
 }

--- a/test/Integration/Writer/UrlSetWriterTest.php
+++ b/test/Integration/Writer/UrlSetWriterTest.php
@@ -44,16 +44,19 @@ XML;
 
         $url->addImage($image);
 
+        $playerLocation = new Component\Video\PlayerLocation('http://www.example.com/videoplayer.swf?video=123');
+
+        $playerLocation = $playerLocation
+            ->withAllowEmbed(Component\Video\PlayerLocationInterface::ALLOW_EMBED_YES)
+            ->withAutoPlay('ap=1')
+        ;
+
         $url->addVideo(new Component\Video\Video(
             'http://www.example.com/thumbs/123.jpg',
             'Grilling steaks for summer',
             'Cook the perfect steak every time.',
             'http://www.example.com/video123.flv',
-            new Component\Video\PlayerLocation(
-                'http://www.example.com/videoplayer.swf?video=123',
-                Component\Video\PlayerLocationInterface::ALLOW_EMBED_YES,
-                'ap=1'
-            )
+            $playerLocation
         ));
 
         $urlSet->addUrl($url);

--- a/test/Unit/Component/Video/PlayerLocationTest.php
+++ b/test/Unit/Component/Video/PlayerLocationTest.php
@@ -38,28 +38,6 @@ class PlayerLocationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->implementsInterface(PlayerLocationInterface::class));
     }
 
-    public function testConstructorSetsValues()
-    {
-        $faker = $this->getFaker();
-
-        $location = $faker->url;
-        $allowEmbed = $faker->randomElement([
-            PlayerLocationInterface::ALLOW_EMBED_NO,
-            PlayerLocationInterface::ALLOW_EMBED_YES,
-        ]);
-        $autoPlay = 'play=true';
-
-        $playerLocation = new PlayerLocation(
-            $location,
-            $allowEmbed,
-            $autoPlay
-        );
-
-        $this->assertSame($location, $playerLocation->location());
-        $this->assertSame($allowEmbed, $playerLocation->allowEmbed());
-        $this->assertSame($autoPlay, $playerLocation->autoPlay());
-    }
-
     public function testDefaults()
     {
         $playerLocation = new PlayerLocation($this->getFaker()->url);
@@ -68,13 +46,60 @@ class PlayerLocationTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($playerLocation->autoPlay());
     }
 
-    public function testInvalidAllowEmbedIsRejected()
+    public function testConstructorSetsValue()
+    {
+        $faker = $this->getFaker();
+
+        $location = $faker->url;
+
+        $playerLocation = new PlayerLocation($location);
+
+        $this->assertSame($location, $playerLocation->location());
+    }
+
+    public function testWithAllowEmbedRejectsInvalidValues()
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
-        new PlayerLocation(
-            $this->getFaker()->url,
-            'foobarbaz'
-        );
+        $faker = $this->getFaker();
+
+        $allowEmbed = $faker->word;
+
+        $playerLocation = new PlayerLocation($faker->url);
+
+        $playerLocation->withAllowEmbed($allowEmbed);
+    }
+
+    public function testWithAllowEmbedClonesObjectAndSetsValue()
+    {
+        $faker = $this->getFaker();
+
+        $allowEmbed = $faker->randomElement([
+            PlayerLocationInterface::ALLOW_EMBED_NO,
+            PlayerLocationInterface::ALLOW_EMBED_YES,
+        ]);
+
+        $playerLocation = new PlayerLocation($faker->url);
+
+        $instance = $playerLocation->withAllowEmbed($allowEmbed);
+
+        $this->assertInstanceOf(PlayerLocation::class, $instance);
+        $this->assertNotSame($playerLocation, $instance);
+        $this->assertSame($allowEmbed, $instance->allowEmbed());
+    }
+
+    public function testWithAutoPlayClonesObjectAndSetsValue()
+    {
+        $faker = $this->getFaker();
+
+        $autoPlay = implode('=', $faker->words(2));
+
+        $playerLocation = new PlayerLocation($faker->url);
+
+        $instance = $playerLocation->withAutoPlay($autoPlay);
+
+        $this->assertInstanceOf(PlayerLocation::class, $instance);
+        $this->assertNotSame($playerLocation, $instance);
+        $this->assertSame($autoPlay, $instance->autoPlay());
     }
 }


### PR DESCRIPTION
This PR

* [x] turns `PlayerLocation` into an immutable object

Follows #56.
