### PR TITLE
Fix: Turn Uploader into immutable object

### DIFF
--- a/src/Component/Video/Uploader.php
+++ b/src/Component/Video/Uploader.php
@@ -21,13 +21,11 @@ final class Uploader implements UploaderInterface
     private $info;
 
     /**
-     * @param string      $name
-     * @param string|null $info
+     * @param string $name
      */
-    public function __construct($name, $info = null)
+    public function __construct($name)
     {
         $this->name = $name;
-        $this->info = $info;
     }
 
     public function name()
@@ -38,5 +36,19 @@ final class Uploader implements UploaderInterface
     public function info()
     {
         return $this->info;
+    }
+
+    /**
+     * @param string $info
+     *
+     * @return static
+     */
+    public function withInfo($info)
+    {
+        $instance = clone $this;
+
+        $instance->info = $info;
+
+        return $instance;
     }
 }

--- a/test/Unit/Component/Video/UploaderTest.php
+++ b/test/Unit/Component/Video/UploaderTest.php
@@ -31,26 +31,36 @@ class UploaderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->implementsInterface(UploaderInterface::class));
     }
 
-    public function testConstructorSetsValues()
+    public function testDefaults()
+    {
+        $uploader = new Uploader($this->getFaker()->name);
+
+        $this->assertNull($uploader->info());
+    }
+
+    public function testConstructorSetsValue()
     {
         $faker = $this->getFaker();
 
         $name = $faker->name;
-        $info = $faker->url;
 
-        $videoUploader = new Uploader(
-            $name,
-            $info
-        );
+        $uploader = new Uploader($name);
 
-        $this->assertSame($name, $videoUploader->name());
-        $this->assertSame($info, $videoUploader->info());
+        $this->assertSame($name, $uploader->name());
     }
 
-    public function testDefaults()
+    public function testWithInfoClonesObjectAndSetsValue()
     {
-        $videoUploader = new Uploader($this->getFaker()->name);
+        $faker = $this->getFaker();
 
-        $this->assertNull($videoUploader->info());
+        $info = $faker->sentence;
+
+        $uploader = new Uploader($faker->url);
+
+        $instance = $uploader->withInfo($info);
+
+        $this->assertInstanceOf(Uploader::class, $instance);
+        $this->assertNotSame($uploader, $instance);
+        $this->assertSame($info, $instance->info());
     }
 }


### PR DESCRIPTION
This PR

* [x] turns `Uploader` into an immutable object

Follows #56.
