### PR TITLE
Fix: Turn Sitemap into an immutable object

### DIFF
--- a/src/Component/Sitemap.php
+++ b/src/Component/Sitemap.php
@@ -23,13 +23,11 @@ final class Sitemap implements SitemapInterface
     private $lastModified;
 
     /**
-     * @param string                 $location
-     * @param DateTimeInterface|null $lastModified
+     * @param string $location
      */
-    public function __construct($location, DateTimeInterface $lastModified = null)
+    public function __construct($location)
     {
         $this->location = $location;
-        $this->lastModified = $lastModified;
     }
 
     public function location()
@@ -39,10 +37,20 @@ final class Sitemap implements SitemapInterface
 
     public function lastModified()
     {
-        if ($this->lastModified === null) {
-            return;
-        }
+        return $this->lastModified;
+    }
 
-        return clone $this->lastModified;
+    /**
+     * @param DateTimeInterface $lastModified
+     *
+     * @return static
+     */
+    public function withLastModified(DateTimeInterface $lastModified)
+    {
+        $instance = clone $this;
+
+        $instance->lastModified = clone $lastModified;
+
+        return $instance;
     }
 }

--- a/test/Integration/Writer/SitemapIndexWriterTest.php
+++ b/test/Integration/Writer/SitemapIndexWriterTest.php
@@ -19,10 +19,10 @@ class SitemapIndexWriterTest extends \PHPUnit_Framework_TestCase
     {
         $index = new SitemapIndex();
 
-        $index->addSitemap(new Sitemap(
-            'http://www.example.com/sitemap1.xml.gz',
-            new DateTimeImmutable('2004-10-01T18:23:17+00:00')
-        ));
+        $sitemap = new Sitemap('http://www.example.com/sitemap1.xml.gz');
+        $sitemap = $sitemap->withLastModified(new DateTimeImmutable('2004-10-01T18:23:17+00:00'));
+
+        $index->addSitemap($sitemap);
 
         $expected = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>

--- a/test/Unit/Component/SitemapTest.php
+++ b/test/Unit/Component/SitemapTest.php
@@ -31,23 +31,6 @@ class SitemapTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->implementsInterface(SitemapInterface::class));
     }
 
-    public function testConstructorSetsValues()
-    {
-        $faker = $this->getFaker();
-
-        $location = $faker->url;
-        $lastModified = $faker->dateTime;
-
-        $sitemap = new Sitemap(
-            $location,
-            $lastModified
-        );
-
-        $this->assertSame($location, $sitemap->location());
-        $this->assertEquals($lastModified, $sitemap->lastModified());
-        $this->assertNotSame($lastModified, $sitemap->lastModified());
-    }
-
     public function testDefaults()
     {
         $location = $this->getFaker()->url;
@@ -56,5 +39,32 @@ class SitemapTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($location, $sitemap->location());
         $this->assertNull($sitemap->lastModified());
+    }
+
+    public function testConstructorSetsLocation()
+    {
+        $faker = $this->getFaker();
+
+        $location = $faker->url;
+
+        $sitemap = new Sitemap($location);
+
+        $this->assertSame($location, $sitemap->location());
+    }
+
+    public function testWithLastModifiedClonesObjectAndSetsValue()
+    {
+        $faker = $this->getFaker();
+
+        $lastModified = $faker->dateTime;
+
+        $sitemap = new Sitemap($faker->url);
+
+        $instance = $sitemap->withLastModified($lastModified);
+
+        $this->assertInstanceOf(Sitemap::class, $instance);
+        $this->assertNotSame($sitemap, $instance);
+        $this->assertEquals($lastModified, $instance->lastModified());
+        $this->assertNotSame($lastModified, $instance->lastModified());
     }
 }


### PR DESCRIPTION
This PR

* [x] turns `Sitemap` into an immutable object 

Follows #56.

