### PR TITLE
Fix: Turn SitemapIndex into an immutable object

### DIFF
--- a/src/Component/SitemapIndex.php
+++ b/src/Component/SitemapIndex.php
@@ -8,39 +8,29 @@
  */
 namespace Refinery29\Sitemap\Component;
 
+use Assert\Assertion;
+
 final class SitemapIndex implements SitemapIndexInterface
 {
     /**
      * @var SitemapInterface[]
      */
-    private $sitemaps = [];
-
-    public function addSitemap(SitemapInterface $sitemap)
-    {
-        if ($this->hasSitemapWithLocation($sitemap->location())) {
-            throw new \InvalidArgumentException(sprintf(
-                'Can not add sitemap with duplicate location "%s"',
-                $sitemap->location()
-            ));
-        }
-
-        $this->sitemaps[] = $sitemap;
-    }
+    private $sitemaps;
 
     /**
-     * @param string $location
-     *
-     * @return bool
+     * @param SitemapInterface[] $sitemaps
      */
-    private function hasSitemapWithLocation($location)
+    public function __construct(array $sitemaps)
     {
-        foreach ($this->sitemaps as $sitemap) {
-            if ($sitemap->location() === $location) {
-                return true;
-            }
-        }
+        Assertion::allIsInstanceOf($sitemaps, SitemapInterface::class);
 
-        return false;
+        $locations = array_map(function (SitemapInterface $sitemap) {
+            return $sitemap->location();
+        }, $sitemaps);
+
+        Assertion::same(array_unique($locations), $locations);
+
+        $this->sitemaps = $sitemaps;
     }
 
     public function sitemaps()

--- a/src/Component/SitemapIndexInterface.php
+++ b/src/Component/SitemapIndexInterface.php
@@ -14,11 +14,6 @@ namespace Refinery29\Sitemap\Component;
 interface SitemapIndexInterface
 {
     /**
-     * @param SitemapInterface $sitemap
-     */
-    public function addSitemap(SitemapInterface $sitemap);
-
-    /**
      * @return SitemapInterface[]
      */
     public function sitemaps();

--- a/test/Integration/Writer/SitemapIndexWriterTest.php
+++ b/test/Integration/Writer/SitemapIndexWriterTest.php
@@ -17,12 +17,12 @@ class SitemapIndexWriterTest extends \PHPUnit_Framework_TestCase
 {
     public function testWriteCreatesXml()
     {
-        $index = new SitemapIndex();
-
         $sitemap = new Sitemap('http://www.example.com/sitemap1.xml.gz');
         $sitemap = $sitemap->withLastModified(new DateTimeImmutable('2004-10-01T18:23:17+00:00'));
 
-        $index->addSitemap($sitemap);
+        $index = new SitemapIndex([
+            $sitemap,
+        ]);
 
         $expected = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
This PR

* [x] turns `SitemapIndex` into an immutable object

Follows #56.
