### PR TITLE
Fix: Turn Url into an immutable object

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $urlSet->add($url);
  
 ### `Image`
 
-You may want to add an image to a `Url` so let's do it:
+You may want to add images to a `Url` so let's do it:
  
 ```php
 use Refinery29\Sitemap\Component;
@@ -61,7 +61,9 @@ $image = $image
     ->withGeoLocation('Majorca, Canyamel')
 ;
 
-$url->addImage($image);
+$url = $url->withImages([
+    $image,
+]);
 ```
 
 :bulb: You can add up to 1.000 images to a `Url`.
@@ -84,7 +86,9 @@ $news = new Component\News\News(
     'Something happened and you should know about it',
 );
 
-$url->addNews($news);
+$url = $url->withNews([
+    $news,
+]);
 ```
 
 :bulb: `News` has many more options, have a look at the source!
@@ -103,7 +107,9 @@ $video = new Component\Video\Video(
     'http://www.example.org/img/funny-video.mov',
 );
 
-$url->addVideo($video);
+$url = $url->withVideos([
+    $video,
+]);
 ```
 
 :bulb: `Video` has many more options, have a look at the source!

--- a/src/Component/Url.php
+++ b/src/Component/Url.php
@@ -72,11 +72,7 @@ final class Url implements UrlInterface
 
     public function lastModified()
     {
-        if ($this->lastModified === null) {
-            return;
-        }
-
-        return clone $this->lastModified;
+        return $this->lastModified;
     }
 
     public function changeFrequency()
@@ -89,21 +85,9 @@ final class Url implements UrlInterface
         return $this->priority;
     }
 
-    public function addImage(ImageInterface $image)
-    {
-        Assertion::lessThan(count($this->images), UrlInterface::IMAGE_MAX_COUNT);
-
-        $this->images[] = $image;
-    }
-
     public function images()
     {
         return $this->images;
-    }
-
-    public function addNews(NewsInterface $news)
-    {
-        $this->news[] = $news;
     }
 
     public function news()
@@ -111,13 +95,99 @@ final class Url implements UrlInterface
         return $this->news;
     }
 
-    public function addVideo(VideoInterface $video)
-    {
-        $this->videos[] = $video;
-    }
-
     public function videos()
     {
         return $this->videos;
+    }
+
+    /**
+     * @param DateTimeInterface $lastModified
+     *
+     * @return static
+     */
+    public function withLastModified(DateTimeInterface $lastModified)
+    {
+        $instance = clone $this;
+
+        $instance->lastModified = clone $lastModified;
+
+        return $instance;
+    }
+
+    /**
+     * @param string $changeFrequency
+     *
+     * @return static
+     */
+    public function withChangeFrequency($changeFrequency)
+    {
+        $instance = clone $this;
+
+        $instance->changeFrequency = $changeFrequency;
+
+        return $instance;
+    }
+
+    /**
+     * @param string $priority
+     *
+     * @return static
+     */
+    public function withPriority($priority)
+    {
+        $instance = clone $this;
+
+        $instance->priority = $priority;
+
+        return $instance;
+    }
+
+    /**
+     * @param ImageInterface[] $images
+     *
+     * @return static
+     */
+    public function withImages(array $images)
+    {
+        Assertion::allIsInstanceOf($images, ImageInterface::class);
+        Assertion::lessOrEqualThan(count($this->images), UrlInterface::IMAGE_MAX_COUNT);
+
+        $instance = clone $this;
+
+        $instance->images = $images;
+
+        return $instance;
+    }
+
+    /**
+     * @param NewsInterface[] $news
+     *
+     * @return static
+     */
+    public function withNews(array $news)
+    {
+        Assertion::allIsInstanceOf($news, NewsInterface::class);
+
+        $instance = clone $this;
+
+        $instance->news = $news;
+
+        return $instance;
+    }
+
+    /**
+     * @param VideoInterface[] $videos
+     *
+     * @return static
+     */
+    public function withVideos(array $videos)
+    {
+        Assertion::allIsInstanceOf($videos, VideoInterface::class);
+
+        $instance = clone $this;
+
+        $instance->videos = $videos;
+
+        return $instance;
     }
 }

--- a/test/Integration/Writer/UrlSetWriterTest.php
+++ b/test/Integration/Writer/UrlSetWriterTest.php
@@ -42,7 +42,9 @@ XML;
         $image = new Component\Image\Image('http://example.com/image.jpg');
         $image = $image->withCaption('Dogs playing poker');
 
-        $url->addImage($image);
+        $url = $url->withImages([
+            $image,
+        ]);
 
         $playerLocation = new Component\Video\PlayerLocation('http://www.example.com/videoplayer.swf?video=123');
 
@@ -51,13 +53,17 @@ XML;
             ->withAutoPlay('ap=1')
         ;
 
-        $url->addVideo(new Component\Video\Video(
+        $video = new Component\Video\Video(
             'http://www.example.com/thumbs/123.jpg',
             'Grilling steaks for summer',
             'Cook the perfect steak every time.',
             'http://www.example.com/video123.flv',
             $playerLocation
-        ));
+        );
+
+        $url = $url->withVideos([
+            $video,
+        ]);
 
         $urlSet->addUrl($url);
 


### PR DESCRIPTION
This PR

* [x] turns `Url` into an immutable object

Follows #56.
