### PR TITLE
Fix: Turn UrlSet into an immutable object

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,9 @@ $ composer require refinery29/sitemap
 
 ## Creating a Sitemap
 
-### `UrlSet`
-
-A sitemap is a set of URLs, so here's how you start:
-
-
-```php
-use Refinery29\Sitemap\Component;
-
-$urlSet = new Component\UrlSet();
-```
-
 ### `Url`
 
-To a `UrlSet`, you can add `Url`s, so let's do it:
+Let's create a `Url`:
 
 ```php
 use Refinery29\Sitemap\Component;
@@ -114,6 +103,18 @@ $url = $url->withVideos([
 
 :bulb: `Video` has many more options, have a look at the source!
 
+### `UrlSet`
+
+Now, let's create a `UrlSet` using the previously created `Url`:
+
+
+```php
+use Refinery29\Sitemap\Component;
+
+$urlSet = new Component\UrlSet([
+    $url,
+]);
+```
 
 ## Writing a Sitemap
 

--- a/src/Component/UrlSet.php
+++ b/src/Component/UrlSet.php
@@ -15,13 +15,14 @@ final class UrlSet implements UrlSetInterface
     /**
      * @var UrlInterface[]
      */
-    private $urls = [];
+    private $urls;
 
-    public function addUrl(UrlInterface $url)
+    public function __construct(array $urls)
     {
-        Assertion::lessThan(count($this->urls), UrlSetInterface::URL_MAX_COUNT);
+        Assertion::allIsInstanceOf($urls, UrlInterface::class);
+        Assertion::lessOrEqualThan(count($urls), UrlSetInterface::URL_MAX_COUNT);
 
-        $this->urls[] = $url;
+        $this->urls = $urls;
     }
 
     public function urls()

--- a/src/Component/UrlSetInterface.php
+++ b/src/Component/UrlSetInterface.php
@@ -25,11 +25,6 @@ interface UrlSetInterface
     const URL_MAX_COUNT = 50000;
 
     /**
-     * @param UrlInterface $url
-     */
-    public function addUrl(UrlInterface $url);
-
-    /**
      * @return UrlInterface[]
      */
     public function urls();

--- a/test/Integration/Writer/UrlSetWriterTest.php
+++ b/test/Integration/Writer/UrlSetWriterTest.php
@@ -15,9 +15,9 @@ class UrlSetWriterTest extends \PHPUnit_Framework_TestCase
 {
     public function testWriteSimpleSitemap()
     {
-        $urlSet = new Component\UrlSet();
-
-        $urlSet->addUrl(new Component\Url('http://www.example.com/foo.html'));
+        $urlSet = new Component\UrlSet([
+            new Component\Url('http://www.example.com/foo.html'),
+        ]);
 
         $writer = new Writer\UrlSetWriter();
 
@@ -35,8 +35,6 @@ XML;
 
     public function testWriteSitemapWithMoreComponents()
     {
-        $urlSet = new Component\UrlSet();
-
         $url = new Component\Url('http://www.example.com/foo.html');
 
         $image = new Component\Image\Image('http://example.com/image.jpg');
@@ -65,7 +63,9 @@ XML;
             $video,
         ]);
 
-        $urlSet->addUrl($url);
+        $urlSet = new Component\UrlSet([
+           $url,
+        ]);
 
         $writer = new Writer\UrlSetWriter();
 

--- a/test/Unit/Component/UrlSetTest.php
+++ b/test/Unit/Component/UrlSetTest.php
@@ -14,6 +14,7 @@ use Refinery29\Sitemap\Component\UrlSet;
 use Refinery29\Sitemap\Component\UrlSetInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 use ReflectionClass;
+use stdClass;
 
 class UrlSetTest extends \PHPUnit_Framework_TestCase
 {
@@ -26,70 +27,54 @@ class UrlSetTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->isFinal());
     }
 
-    public function testDefaults()
-    {
-        $urlSet = new UrlSet();
-
-        $this->assertInternalType('array', $urlSet->urls());
-        $this->assertCount(0, $urlSet->urls());
-    }
-
-    public function testCanAddUrl()
-    {
-        $url = $this->getUrlMock();
-
-        $urlSet = new UrlSet();
-        $urlSet->addUrl($url);
-
-        $this->assertInternalType('array', $urlSet->urls());
-        $this->assertCount(1, $urlSet->urls());
-        $this->assertSame($url, $urlSet->urls()[0]);
-    }
-
-    public function testCanAddALotOfUrls()
-    {
-        $urls = array_fill(
-            0,
-            UrlSetInterface::URL_MAX_COUNT - 1,
-            $this->getUrlMock()
-        );
-
-        $urlSet = new UrlSet();
-
-        $reflectionProperty = new \ReflectionProperty(UrlSet::class, 'urls');
-
-        $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue($urlSet, $urls);
-
-        $url = $this->getUrlMock();
-
-        $urlSet->addUrl($url);
-
-        $this->assertInternalType('array', $urlSet->urls());
-        $this->assertCount(UrlSetInterface::URL_MAX_COUNT, $urlSet->urls());
-        $this->assertContains($url, $urlSet->urls());
-    }
-
-    public function testCanNotAddMoreUrlMaxCountUrls()
+    /**
+     * @dataProvider providerInvalidUrls
+     *
+     * @param mixed $urls
+     */
+    public function testConstructorRejectsInvalidValue($urls)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
-        $urls = array_fill(
-            0,
-            UrlSetInterface::URL_MAX_COUNT,
-            $this->getUrlMock()
-        );
+        new UrlSet($urls);
+    }
 
-        $urlSet = new UrlSet();
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidUrls()
+    {
+        $values = [
+            [
+                $this->getUrlMock(),
+                $this->getUrlMock(),
+                new stdClass(),
+            ],
+            array_fill(
+                0,
+                UrlSetInterface::URL_MAX_COUNT + 1,
+                $this->getUrlMock()
+            ),
+        ];
 
-        $reflectionProperty = new \ReflectionProperty(UrlSet::class, 'urls');
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
+    }
 
-        $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue($urlSet, $urls);
+    public function testConstructorSetsValue()
+    {
+        $urls = [
+            $this->getUrlMock(),
+            $this->getUrlMock(),
+            $this->getUrlMock(),
+        ];
 
-        $url = $this->getUrlMock();
+        $urlSet = new UrlSet($urls);
 
-        $urlSet->addUrl($url);
+        $this->assertSame($urls, $urlSet->urls());
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] turns `UrlSet` into an immutable object 

Follows #56.

