### PR TITLE
Fix: Reject non-string values in Component\Image

### DIFF
--- a/src/Component/Image/Image.php
+++ b/src/Component/Image/Image.php
@@ -9,6 +9,7 @@
 namespace Refinery29\Sitemap\Component\Image;
 
 use Assert\Assertion;
+use InvalidArgumentException;
 
 final class Image implements ImageInterface
 {
@@ -39,6 +40,8 @@ final class Image implements ImageInterface
 
     /**
      * @param string $location
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($location)
     {
@@ -75,10 +78,14 @@ final class Image implements ImageInterface
     /**
      * @param string $title
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withTitle($title)
     {
+        Assertion::string($title);
+
         $instance = clone $this;
 
         $instance->title = $title;
@@ -89,10 +96,14 @@ final class Image implements ImageInterface
     /**
      * @param string $caption
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withCaption($caption)
     {
+        Assertion::string($caption);
+
         $instance = clone $this;
 
         $instance->caption = $caption;
@@ -103,10 +114,14 @@ final class Image implements ImageInterface
     /**
      * @param string $geoLocation
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withGeoLocation($geoLocation)
     {
+        Assertion::string($geoLocation);
+
         $instance = clone $this;
 
         $instance->geoLocation = $geoLocation;
@@ -117,10 +132,14 @@ final class Image implements ImageInterface
     /**
      * @param string $licence
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withLicence($licence)
     {
+        Assertion::string($licence);
+
         $instance = clone $this;
 
         $instance->licence = $licence;

--- a/test/Unit/Component/Image/ImageTest.php
+++ b/test/Unit/Component/Image/ImageTest.php
@@ -87,6 +87,45 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($location, $image->location());
     }
 
+    /**
+     * @dataProvider providerInvalidString
+     *
+     * @param mixed $title
+     */
+    public function testWithTitleRejectsInvalidValue($title)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $location = $this->getFaker()->url;
+
+        $image = new Image($location);
+
+        $image->withTitle($title);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidString()
+    {
+        $faker = $this->getFaker();
+
+        $values = [
+            null,
+            $faker->boolean(),
+            $faker->words,
+            $faker->randomNumber(),
+            $faker->randomFloat(),
+            new \stdClass(),
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
+    }
+
     public function testWithTitleClonesObjectAndSetsValue()
     {
         $faker = $this->getFaker();
@@ -100,6 +139,22 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Image::class, $instance);
         $this->assertNotSame($image, $instance);
         $this->assertSame($title, $instance->title());
+    }
+
+    /**
+     * @dataProvider providerInvalidString
+     *
+     * @param mixed $caption
+     */
+    public function testWithCaptionRejectsInvalidValue($caption)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $location = $this->getFaker()->url;
+
+        $image = new Image($location);
+
+        $image->withCaption($caption);
     }
 
     public function testWithCaptionClonesObjectAndSetsValue()
@@ -117,6 +172,22 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($caption, $instance->caption());
     }
 
+    /**
+     * @dataProvider providerInvalidString
+     *
+     * @param mixed $geoLocation
+     */
+    public function testWithGeoLocationRejectsInvalidValue($geoLocation)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $location = $this->getFaker()->url;
+
+        $image = new Image($location);
+
+        $image->withGeoLocation($geoLocation);
+    }
+
     public function testWithGeoLocationClonesObjectAndSetsValue()
     {
         $faker = $this->getFaker();
@@ -130,6 +201,22 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Image::class, $instance);
         $this->assertNotSame($image, $instance);
         $this->assertSame($geoLocation, $instance->geoLocation());
+    }
+
+    /**
+     * @dataProvider providerInvalidString
+     *
+     * @param mixed $licence
+     */
+    public function testWithLicenceRejectsInvalidValue($licence)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $location = $this->getFaker()->url;
+
+        $image = new Image($location);
+
+        $image->withLicence($licence);
     }
 
     public function testWithLicenceClonesObjectAndSetsValue()


### PR DESCRIPTION
This PR

* [x] asserts that non-string values are rejected
* [x] rejects non-string values
