### PR TITLE
Fix: Reject non-string values in Component\News

### DIFF
--- a/src/Component/News/News.php
+++ b/src/Component/News/News.php
@@ -10,6 +10,7 @@ namespace Refinery29\Sitemap\Component\News;
 
 use Assert\Assertion;
 use DateTimeInterface;
+use InvalidArgumentException;
 
 final class News implements NewsInterface
 {
@@ -55,6 +56,8 @@ final class News implements NewsInterface
      */
     public function __construct(PublicationInterface $publication, DateTimeInterface $publicationDate, $title)
     {
+        Assertion::string($title);
+
         $this->publication = $publication;
         $this->publicationDate = $publicationDate;
         $this->title = $title;
@@ -98,6 +101,8 @@ final class News implements NewsInterface
     /**
      * @param string $access
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withAccess($access)
@@ -118,6 +123,8 @@ final class News implements NewsInterface
 
     /**
      * @param array $genres
+     *
+     * @throws InvalidArgumentException
      *
      * @return static
      */
@@ -143,10 +150,14 @@ final class News implements NewsInterface
     /**
      * @param array $keywords
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withKeywords(array $keywords)
     {
+        Assertion::allString($keywords);
+
         $instance = clone $this;
 
         $instance->keywords = $keywords;
@@ -157,10 +168,13 @@ final class News implements NewsInterface
     /**
      * @param array $stockTickers
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withStockTickers(array $stockTickers)
     {
+        Assertion::allString($stockTickers);
         Assertion::lessOrEqualThan(count($stockTickers), NewsInterface::STOCK_TICKERS_MAX_COUNT);
 
         $instance = clone $this;

--- a/test/Unit/Component/News/NewsTest.php
+++ b/test/Unit/Component/News/NewsTest.php
@@ -55,6 +55,47 @@ class NewsTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $news->stockTickers());
     }
 
+    /**
+     * @dataProvider providerInvalidString
+     *
+     * @param mixed $title
+     */
+    public function testConstructorRejectsInvalidTitle($title)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        new News(
+            $this->getPublicationMock(),
+            $faker->dateTime,
+            $title
+        );
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidString()
+    {
+        $faker = $this->getFaker();
+
+        $values = [
+            null,
+            $faker->boolean(),
+            $faker->words,
+            $faker->randomNumber(),
+            $faker->randomFloat(),
+            new \stdClass(),
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
+    }
+
     public function testConstructorSetsValues()
     {
         $faker = $this->getFaker();
@@ -157,6 +198,32 @@ class NewsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($genres, $instance->genres());
     }
 
+    /**
+     * @dataProvider providerInvalidString
+     *
+     * @param mixed $keyword
+     */
+    public function testWithKeywordsRejectsInvalidValues($keyword)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $keywords = [
+            $faker->word,
+            $faker->word,
+            $keyword,
+        ];
+
+        $news = new News(
+            $this->getPublicationMock(),
+            $faker->dateTime,
+            $faker->sentence()
+        );
+
+        $news->withKeywords($keywords);
+    }
+
     public function testWithKeywordsClonesObjectAndSetsValue()
     {
         $faker = $this->getFaker();
@@ -174,6 +241,32 @@ class NewsTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(News::class, $instance);
         $this->assertNotSame($news, $instance);
         $this->assertSame($keywords, $instance->keywords());
+    }
+
+    /**
+     * @dataProvider providerInvalidString
+     *
+     * @param mixed $stockTicker
+     */
+    public function testWithStockTickersRejectsInvalidValues($stockTicker)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $stockTickers = [
+            $faker->word,
+            $faker->word,
+            $stockTicker,
+        ];
+
+        $news = new News(
+            $this->getPublicationMock(),
+            $faker->dateTime,
+            $faker->sentence()
+        );
+
+        $news->withStockTickers($stockTickers);
     }
 
     public function testWithStockTickersRejectsTooManyValues()


### PR DESCRIPTION
This PR

* [x] asserts that non-string values are rejected by `Component\News`
* [x] rejects non-string values 

Follows #74.
