### PR TITLE
Fix: Reject non-string values in Component\News\Publication

### DIFF
--- a/src/Component/News/Publication.php
+++ b/src/Component/News/Publication.php
@@ -8,6 +8,9 @@
  */
 namespace Refinery29\Sitemap\Component\News;
 
+use Assert\Assertion;
+use InvalidArgumentException;
+
 final class Publication implements PublicationInterface
 {
     /**
@@ -23,9 +26,14 @@ final class Publication implements PublicationInterface
     /**
      * @param string $name
      * @param string $language
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($name, $language)
     {
+        Assertion::string($name);
+        Assertion::string($language);
+
         $this->name = $name;
         $this->language = $language;
     }

--- a/test/Unit/Component/News/PublicationTest.php
+++ b/test/Unit/Component/News/PublicationTest.php
@@ -8,6 +8,7 @@
  */
 namespace Refinery29\Sitemap\Test\Unit\Component\News;
 
+use InvalidArgumentException;
 use Refinery29\Sitemap\Component\News\Publication;
 use Refinery29\Sitemap\Component\News\PublicationInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
@@ -29,6 +30,40 @@ class PublicationTest extends \PHPUnit_Framework_TestCase
         $reflectionClass = new ReflectionClass(Publication::class);
 
         $this->assertTrue($reflectionClass->implementsInterface(PublicationInterface::class));
+    }
+
+    /**
+     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
+     *
+     * @param mixed $name
+     */
+    public function testConstructorRejectsInvalidName($name)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $language = $this->getFaker()->languageCode;
+
+        new Publication(
+            $name,
+            $language
+        );
+    }
+
+    /**
+     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
+     *
+     * @param mixed $language
+     */
+    public function testConstructorRejectsInvalidLanguage($language)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $name = $this->getFaker()->sentence();
+
+        new Publication(
+            $name,
+            $language
+        );
     }
 
     public function testConstructorSetsValues()


### PR DESCRIPTION
This PR

* [x] asserts that non-string values are rejected by the constructor of `Component\News\Publication`
* [x] rejects non-string values

