### PR TITLE
Fix: Extract DataProvider

### DIFF
--- a/test/Unit/Component/DataProvider.php
+++ b/test/Unit/Component/DataProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+namespace Refinery29\Sitemap\Test\Unit\Component;
+
+use Refinery29\Test\Util\Faker\GeneratorTrait;
+
+class DataProvider
+{
+    use GeneratorTrait;
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidString()
+    {
+        $faker = $this->getFaker();
+
+        $values = [
+            null,
+            $faker->boolean(),
+            $faker->words,
+            $faker->randomNumber(),
+            $faker->randomFloat(),
+            new \stdClass(),
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
+    }
+}

--- a/test/Unit/Component/Image/ImageTest.php
+++ b/test/Unit/Component/Image/ImageTest.php
@@ -88,7 +88,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
      *
      * @param mixed $title
      */
@@ -101,29 +101,6 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $image = new Image($location);
 
         $image->withTitle($title);
-    }
-
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidString()
-    {
-        $faker = $this->getFaker();
-
-        $values = [
-            null,
-            $faker->boolean(),
-            $faker->words,
-            $faker->randomNumber(),
-            $faker->randomFloat(),
-            new \stdClass(),
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
     }
 
     public function testWithTitleClonesObjectAndSetsValue()
@@ -142,7 +119,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
      *
      * @param mixed $caption
      */
@@ -173,7 +150,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
      *
      * @param mixed $geoLocation
      */
@@ -204,7 +181,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
      *
      * @param mixed $licence
      */

--- a/test/Unit/Component/News/NewsTest.php
+++ b/test/Unit/Component/News/NewsTest.php
@@ -56,7 +56,7 @@ class NewsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
      *
      * @param mixed $title
      */
@@ -71,29 +71,6 @@ class NewsTest extends \PHPUnit_Framework_TestCase
             $faker->dateTime,
             $title
         );
-    }
-
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidString()
-    {
-        $faker = $this->getFaker();
-
-        $values = [
-            null,
-            $faker->boolean(),
-            $faker->words,
-            $faker->randomNumber(),
-            $faker->randomFloat(),
-            new \stdClass(),
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
     }
 
     public function testConstructorSetsValues()
@@ -199,7 +176,7 @@ class NewsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
      *
      * @param mixed $keyword
      */
@@ -244,7 +221,7 @@ class NewsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
      *
      * @param mixed $stockTicker
      */


### PR DESCRIPTION
This PR

* [x] extracts a `DataProvider` 

Related to #78.