### PR TITLE
Fix: Move data provider

### DIFF
--- a/test/Unit/Component/Image/ImageTest.php
+++ b/test/Unit/Component/Image/ImageTest.php
@@ -88,7 +88,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Util\DataProvider\InvalidString::data
      *
      * @param mixed $title
      */
@@ -119,7 +119,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Util\DataProvider\InvalidString::data
      *
      * @param mixed $caption
      */
@@ -150,7 +150,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Util\DataProvider\InvalidString::data
      *
      * @param mixed $geoLocation
      */
@@ -181,7 +181,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Util\DataProvider\InvalidString::data
      *
      * @param mixed $licence
      */

--- a/test/Unit/Component/News/NewsTest.php
+++ b/test/Unit/Component/News/NewsTest.php
@@ -56,7 +56,7 @@ class NewsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Util\DataProvider\InvalidString::data
      *
      * @param mixed $title
      */
@@ -176,7 +176,7 @@ class NewsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Util\DataProvider\InvalidString::data
      *
      * @param mixed $keyword
      */
@@ -221,7 +221,7 @@ class NewsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Util\DataProvider\InvalidString::data
      *
      * @param mixed $stockTicker
      */

--- a/test/Unit/Component/News/PublicationTest.php
+++ b/test/Unit/Component/News/PublicationTest.php
@@ -33,7 +33,7 @@ class PublicationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Util\DataProvider\InvalidString::data
      *
      * @param mixed $name
      */
@@ -50,7 +50,7 @@ class PublicationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider Refinery29\Sitemap\Test\Unit\Component\DataProvider::providerInvalidString
+     * @dataProvider Refinery29\Sitemap\Test\Util\DataProvider\InvalidString::data
      *
      * @param mixed $language
      */

--- a/test/Util/DataProvider/InvalidString.php
+++ b/test/Util/DataProvider/InvalidString.php
@@ -6,18 +6,18 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-namespace Refinery29\Sitemap\Test\Unit\Component;
+namespace Refinery29\Sitemap\Test\Util\DataProvider;
 
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class DataProvider
+class InvalidString
 {
     use GeneratorTrait;
 
     /**
      * @return \Generator
      */
-    public function providerInvalidString()
+    public function data()
     {
         $faker = $this->getFaker();
 


### PR DESCRIPTION
This PR

* [x] moves a data provider 

Related to https://github.com/refinery29/test-util/pull/21.

:information_desk_person: Moving it now makes it easier to change when the referenced PR has been merged and tagged.

