### PR TITLE
Fix: Reject invalid location in Component\Video\GalleryLocation

### DIFF
--- a/src/Component/Video/GalleryLocation.php
+++ b/src/Component/Video/GalleryLocation.php
@@ -8,6 +8,9 @@
  */
 namespace Refinery29\Sitemap\Component\Video;
 
+use Assert\Assertion;
+use InvalidArgumentException;
+
 final class GalleryLocation implements GalleryLocationInterface
 {
     /**
@@ -22,9 +25,13 @@ final class GalleryLocation implements GalleryLocationInterface
 
     /**
      * @param string $location
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($location)
     {
+        Assertion::url($location);
+
         $this->location = $location;
     }
 

--- a/test/Unit/Component/Video/GalleryLocationTest.php
+++ b/test/Unit/Component/Video/GalleryLocationTest.php
@@ -8,6 +8,7 @@
  */
 namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
+use InvalidArgumentException;
 use Refinery29\Sitemap\Component\Video\GalleryLocation;
 use Refinery29\Sitemap\Component\Video\GalleryLocationInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
@@ -36,6 +37,18 @@ class GalleryLocationTest extends \PHPUnit_Framework_TestCase
         $galleryLocation = new GalleryLocation($this->getFaker()->url);
 
         $this->assertNull($galleryLocation->title());
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidUrl::data
+     *
+     * @param mixed $location
+     */
+    public function testConstructorRejectsInvalidLocation($location)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        new GalleryLocation($location);
     }
 
     public function testConstructorSetsValue()


### PR DESCRIPTION
This PR

* [x] asserts that invalid URLs are rejected by the constructor of `Component\Video\GalleryLocation`
* [x] rejects invalid URLs
