### PR TITLE
Fix: Reject invalid string in Component\Video\GalleryLocation

### DIFF
--- a/src/Component/Video/GalleryLocation.php
+++ b/src/Component/Video/GalleryLocation.php
@@ -48,10 +48,14 @@ final class GalleryLocation implements GalleryLocationInterface
     /**
      * @param string $title
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withTitle($title)
     {
+        Assertion::string($title);
+
         $instance = clone $this;
 
         $instance->title = $title;

--- a/test/Unit/Component/Video/GalleryLocationTest.php
+++ b/test/Unit/Component/Video/GalleryLocationTest.php
@@ -62,6 +62,22 @@ class GalleryLocationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($location, $galleryLocation->location());
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data
+     * 
+     * @param mixed $title
+     */
+    public function testWithTitleRejectsInvalidValue($title)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $location = $this->getFaker()->url;
+
+        $galleryLocation = new GalleryLocation($location);
+
+        $galleryLocation->withTitle($title);
+    }
+
     public function testWithTitleClonesObjectAndSetsValue()
     {
         $faker = $this->getFaker();


### PR DESCRIPTION
This PR

* [x] asserts that non-strings are rejected by `Component\Video\GalleryLocation::withTitle()`
* [x] rejects non-string values
