### PR TITLE
Fix: Reject invalid location in Component\Video\PlayerLocation

### DIFF
--- a/src/Component/Video/PlayerLocation.php
+++ b/src/Component/Video/PlayerLocation.php
@@ -9,6 +9,7 @@
 namespace Refinery29\Sitemap\Component\Video;
 
 use Assert\Assertion;
+use InvalidArgumentException;
 
 final class PlayerLocation implements PlayerLocationInterface
 {
@@ -29,9 +30,13 @@ final class PlayerLocation implements PlayerLocationInterface
 
     /**
      * @param string $location
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($location)
     {
+        Assertion::url($location);
+
         $this->location = $location;
     }
 

--- a/test/Unit/Component/Video/PlayerLocationTest.php
+++ b/test/Unit/Component/Video/PlayerLocationTest.php
@@ -46,6 +46,18 @@ class PlayerLocationTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($playerLocation->autoPlay());
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidUrl::data
+     *
+     * @param mixed $location
+     */
+    public function testConstructorRejectsInvalidLocation($location)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        new PlayerLocation($location);
+    }
+
     public function testConstructorSetsValue()
     {
         $faker = $this->getFaker();


### PR DESCRIPTION
This PR

* [x] asserts that invalid URLs are rejected by the constructor of `Component\Video\PlayerLocation`
* [x] rejects invalid URLs

Follows #83.
