### PR TITLE
Fix: Update docblocks

### DIFF
--- a/src/Component/News/News.php
+++ b/src/Component/News/News.php
@@ -53,6 +53,8 @@ final class News implements NewsInterface
      * @param PublicationInterface $publication
      * @param DateTimeInterface    $publicationDate
      * @param string               $title
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct(PublicationInterface $publication, DateTimeInterface $publicationDate, $title)
     {

--- a/src/Component/SitemapIndex.php
+++ b/src/Component/SitemapIndex.php
@@ -9,6 +9,7 @@
 namespace Refinery29\Sitemap\Component;
 
 use Assert\Assertion;
+use InvalidArgumentException;
 
 final class SitemapIndex implements SitemapIndexInterface
 {
@@ -19,6 +20,8 @@ final class SitemapIndex implements SitemapIndexInterface
 
     /**
      * @param SitemapInterface[] $sitemaps
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct(array $sitemaps)
     {

--- a/src/Component/Url.php
+++ b/src/Component/Url.php
@@ -10,6 +10,7 @@ namespace Refinery29\Sitemap\Component;
 
 use Assert\Assertion;
 use DateTimeInterface;
+use InvalidArgumentException;
 use Refinery29\Sitemap\Component\Image\ImageInterface;
 use Refinery29\Sitemap\Component\News\NewsInterface;
 use Refinery29\Sitemap\Component\Video\VideoInterface;
@@ -145,6 +146,8 @@ final class Url implements UrlInterface
     /**
      * @param ImageInterface[] $images
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withImages(array $images)
@@ -162,6 +165,8 @@ final class Url implements UrlInterface
     /**
      * @param NewsInterface[] $news
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withNews(array $news)
@@ -177,6 +182,8 @@ final class Url implements UrlInterface
 
     /**
      * @param VideoInterface[] $videos
+     *
+     * @throws InvalidArgumentException
      *
      * @return static
      */

--- a/src/Component/UrlSet.php
+++ b/src/Component/UrlSet.php
@@ -9,6 +9,7 @@
 namespace Refinery29\Sitemap\Component;
 
 use Assert\Assertion;
+use InvalidArgumentException;
 
 final class UrlSet implements UrlSetInterface
 {
@@ -17,6 +18,11 @@ final class UrlSet implements UrlSetInterface
      */
     private $urls;
 
+    /**
+     * @param array[] $urls
+     *
+     * @throws InvalidArgumentException
+     */
     public function __construct(array $urls)
     {
         Assertion::allIsInstanceOf($urls, UrlInterface::class);

--- a/src/Component/Video/Platform.php
+++ b/src/Component/Video/Platform.php
@@ -9,6 +9,7 @@
 namespace Refinery29\Sitemap\Component\Video;
 
 use Assert\Assertion;
+use InvalidArgumentException;
 
 final class Platform implements PlatformInterface
 {
@@ -24,6 +25,8 @@ final class Platform implements PlatformInterface
 
     /**
      * @param string $relationship
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($relationship)
     {
@@ -49,6 +52,8 @@ final class Platform implements PlatformInterface
 
     /**
      * @param array $types
+     *
+     * @throws InvalidArgumentException
      *
      * @return static
      */

--- a/src/Component/Video/PlayerLocation.php
+++ b/src/Component/Video/PlayerLocation.php
@@ -58,6 +58,8 @@ final class PlayerLocation implements PlayerLocationInterface
     /**
      * @param string $allowEmbed
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withAllowEmbed($allowEmbed)

--- a/src/Component/Video/Price.php
+++ b/src/Component/Video/Price.php
@@ -9,6 +9,7 @@
 namespace Refinery29\Sitemap\Component\Video;
 
 use Assert\Assertion;
+use InvalidArgumentException;
 
 final class Price implements PriceInterface
 {
@@ -35,6 +36,8 @@ final class Price implements PriceInterface
     /**
      * @param float  $value
      * @param string $currency
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($value, $currency)
     {
@@ -67,6 +70,8 @@ final class Price implements PriceInterface
     /**
      * @param string $type
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withType($type)
@@ -87,6 +92,8 @@ final class Price implements PriceInterface
 
     /**
      * @param string $resolution
+     *
+     * @throws InvalidArgumentException
      *
      * @return static
      */

--- a/src/Component/Video/Restriction.php
+++ b/src/Component/Video/Restriction.php
@@ -24,6 +24,8 @@ final class Restriction implements RestrictionInterface
 
     /**
      * @param string $relationship
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($relationship)
     {

--- a/src/Component/Video/Video.php
+++ b/src/Component/Video/Video.php
@@ -10,6 +10,7 @@ namespace Refinery29\Sitemap\Component\Video;
 
 use Assert\Assertion;
 use DateTimeInterface;
+use InvalidArgumentException;
 
 final class Video implements VideoInterface
 {
@@ -119,6 +120,8 @@ final class Video implements VideoInterface
      * @param string                       $description
      * @param string|null                  $contentLocation
      * @param PlayerLocationInterface|null $playerLocation
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct(
         $thumbnailLocation,
@@ -261,6 +264,8 @@ final class Video implements VideoInterface
     /**
      * @param int $duration
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withDuration($duration)
@@ -307,6 +312,8 @@ final class Video implements VideoInterface
     /**
      * @param float $rating
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withRating($rating)
@@ -325,6 +332,8 @@ final class Video implements VideoInterface
     /**
      * @param int $viewCount
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withViewCount($viewCount)
@@ -342,6 +351,8 @@ final class Video implements VideoInterface
     /**
      * @param string $familyFriendly
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withFamilyFriendly($familyFriendly)
@@ -357,6 +368,8 @@ final class Video implements VideoInterface
 
     /**
      * @param TagInterface[] $tags
+     *
+     * @throws InvalidArgumentException
      *
      * @return static
      */
@@ -374,6 +387,8 @@ final class Video implements VideoInterface
 
     /**
      * @param string $category
+     *
+     * @throws InvalidArgumentException
      *
      * @return static
      */
@@ -406,6 +421,8 @@ final class Video implements VideoInterface
     /**
      * @param PriceInterface[] $prices
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withPrices($prices)
@@ -421,6 +438,8 @@ final class Video implements VideoInterface
 
     /**
      * @param string $requiresSubscription
+     *
+     * @throws InvalidArgumentException
      *
      * @return static
      */
@@ -469,7 +488,9 @@ final class Video implements VideoInterface
     }
 
     /**
-     * @param $live
+     * @param string $live
+     *
+     * @throws InvalidArgumentException
      *
      * @return static
      */


### PR DESCRIPTION
This PR

* [x] updates docblocks

:information_desk_person: Most methods using assertions didn't have `@throws` annotations, this fixes it.
