### PR TITLE
Fix: Reject null values

### DIFF
--- a/src/Component/News/News.php
+++ b/src/Component/News/News.php
@@ -114,7 +114,7 @@ final class News implements NewsInterface
             NewsInterface::ACCESS_SUBSCRIPTION,
         ];
 
-        Assertion::nullOrChoice($access, $choices);
+        Assertion::choice($access, $choices);
 
         $instance = clone $this;
 

--- a/src/Component/Video/PlayerLocation.php
+++ b/src/Component/Video/PlayerLocation.php
@@ -69,7 +69,7 @@ final class PlayerLocation implements PlayerLocationInterface
             PlayerLocationInterface::ALLOW_EMBED_YES,
         ];
 
-        Assertion::nullOrChoice($allowEmbed, $choices);
+        Assertion::choice($allowEmbed, $choices);
 
         $instance = clone $this;
 

--- a/test/Unit/Component/News/NewsTest.php
+++ b/test/Unit/Component/News/NewsTest.php
@@ -92,13 +92,16 @@ class NewsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($title, $news->title());
     }
 
-    public function testWithAccessRejectsInvalidValue()
+    /**
+     * @dataProvider providerInvalidAccess
+     *
+     * @param mixed $access
+     */
+    public function testWithAccessRejectsInvalidValue($access)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
         $faker = $this->getFaker();
-
-        $access = $faker->sentence();
 
         $news = new News(
             $this->getPublicationMock(),
@@ -107,6 +110,23 @@ class NewsTest extends \PHPUnit_Framework_TestCase
         );
 
         $news->withAccess($access);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidAccess()
+    {
+        $values = [
+            null,
+            $this->getFaker()->sentence(),
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
     }
 
     public function testWithAccessClonesObjectAndSetsValue()

--- a/test/Unit/Component/Video/PlayerLocationTest.php
+++ b/test/Unit/Component/Video/PlayerLocationTest.php
@@ -69,17 +69,37 @@ class PlayerLocationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($location, $playerLocation->location());
     }
 
-    public function testWithAllowEmbedRejectsInvalidValues()
+    /**
+     * @dataProvider providerInvalidAllowEmbed
+     *
+     * @param $allowEmbed
+     */
+    public function testWithAllowEmbedRejectsInvalidValues($allowEmbed)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
-        $allowEmbed = $faker->word;
-
         $playerLocation = new PlayerLocation($faker->url);
 
         $playerLocation->withAllowEmbed($allowEmbed);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidAllowEmbed()
+    {
+        $values = [
+            null,
+            $this->getFaker()->sentence(),
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
     }
 
     public function testWithAllowEmbedClonesObjectAndSetsValue()


### PR DESCRIPTION
This PR

* [x] asserts that `null` values are rejected
* [x] rejects `null` values
