### PR TITLE
Fix: Assert that null values are rejected

### DIFF
--- a/test/Unit/Component/Video/PlatformTest.php
+++ b/test/Unit/Component/Video/PlatformTest.php
@@ -43,11 +43,33 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $platform->types());
     }
 
-    public function testConstructorRejectsInvalidRelationship()
+    /**
+     * @dataProvider providerInvalidRelationship
+     *
+     * @param mixed $relationship
+     */
+    public function testConstructorRejectsInvalidRelationship($relationship)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
-        new Platform('foo');
+        new Platform($relationship);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidRelationship()
+    {
+        $values = [
+            null,
+            $this->getFaker()->sentence(),
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
     }
 
     public function testConstructorSetsValue()

--- a/test/Unit/Component/Video/PriceTest.php
+++ b/test/Unit/Component/Video/PriceTest.php
@@ -104,13 +104,16 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($currency, $price->currency());
     }
 
-    public function testWithTypeRejectsInvalidType()
+    /**
+     * @dataProvider providerInvalidType
+     *
+     * @param mixed $type
+     */
+    public function testWithTypeRejectsInvalidType($type)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
         $faker = $this->getFaker();
-
-        $type = $faker->word;
 
         $price = new Price(
             $faker->randomFloat(2, 0.01),
@@ -118,6 +121,23 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         );
 
         $price->withType($type);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidType()
+    {
+        $values = [
+            null,
+            $this->getFaker()->sentence(),
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
     }
 
     public function testWithTypeClonesObjectAndSetsValue()
@@ -141,13 +161,16 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($type, $instance->type());
     }
 
-    public function testWithResolutionRejectsInvalidResolution()
+    /**
+     * @dataProvider providerInvalidResolution
+     *
+     * @param mixed $resolution
+     */
+    public function testWithResolutionRejectsInvalidResolution($resolution)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
         $faker = $this->getFaker();
-
-        $resolution = $faker->word;
 
         $price = new Price(
             $faker->randomFloat(2, 0.01),
@@ -155,6 +178,23 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         );
 
         $price->withResolution($resolution);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidResolution()
+    {
+        $values = [
+            null,
+            $this->getFaker()->sentence(),
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
     }
 
     public function testWithResolutionClonesObjectAndSetsValue()

--- a/test/Unit/Component/Video/RestrictionTest.php
+++ b/test/Unit/Component/Video/RestrictionTest.php
@@ -45,13 +45,33 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $restriction->countryCodes());
     }
 
-    public function testConstructorRejectsInvalidRestriction()
+    /**
+     * @dataProvider providerInvalidRestriction
+     *
+     * @param mixed $restriction
+     */
+    public function testConstructorRejectsInvalidRestriction($restriction)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
-        $restriction = $this->getFaker()->word;
-
         new Restriction($restriction);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidRestriction()
+    {
+        $values = [
+            null,
+            $this->getFaker()->sentence(),
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
     }
 
     public function testConstructorSetsValue()


### PR DESCRIPTION
This PR

* [x] asserts that `null` values are rejected