### PR TITLE
Fix: Reject non-string country codes from Component\Video\Restriction

### DIFF
--- a/src/Component/Video/Restriction.php
+++ b/src/Component/Video/Restriction.php
@@ -54,10 +54,14 @@ final class Restriction implements RestrictionInterface
     /**
      * @param array $countryCodes
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withCountryCodes(array $countryCodes)
     {
+        Assertion::allString($countryCodes);
+
         $instance = clone $this;
 
         $instance->countryCodes = $countryCodes;

--- a/test/Unit/Component/Video/RestrictionTest.php
+++ b/test/Unit/Component/Video/RestrictionTest.php
@@ -87,6 +87,31 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($relationship, $restriction->relationship());
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data
+     *
+     * @param mixed $countryCode
+     */
+    public function testWithCountryCodeRejectsInvalidCountryCodes($countryCode)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $countryCodes = [
+            $faker->countryCode,
+            $countryCode,
+        ];
+
+        $restriction = new Restriction(
+            $faker->randomElement([
+            RestrictionInterface::RELATIONSHIP_ALLOW,
+            RestrictionInterface::RELATIONSHIP_DENY,
+        ]));
+
+        $restriction->withCountryCodes($countryCodes);
+    }
+
     public function testWithCountryCodesClonesObjectAndSetsValue()
     {
         $faker = $this->getFaker();


### PR DESCRIPTION
This PR

* [x] asserts that non-string country codes are rejected by `Component\Video\Restriction::withCountryCodes()`
* [x] rejects non-string country codes
