### PR TITLE
Fix: Reject non-string value from Component\Video\Tag

### DIFF
--- a/src/Component/Video/Tag.php
+++ b/src/Component/Video/Tag.php
@@ -9,6 +9,9 @@
 
 namespace Refinery29\Sitemap\Component\Video;
 
+use Assert\Assertion;
+use InvalidArgumentException;
+
 final class Tag implements TagInterface
 {
     /**
@@ -18,9 +21,13 @@ final class Tag implements TagInterface
 
     /**
      * @param string $content
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($content)
     {
+        Assertion::string($content);
+
         $this->content = $content;
     }
 

--- a/test/Unit/Component/Video/TagTest.php
+++ b/test/Unit/Component/Video/TagTest.php
@@ -9,6 +9,7 @@
 
 namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
+use InvalidArgumentException;
 use Refinery29\Sitemap\Component\Video\Tag;
 use Refinery29\Sitemap\Component\Video\TagInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
@@ -30,6 +31,18 @@ class TagTest extends \PHPUnit_Framework_TestCase
         $reflectionClass = new ReflectionClass(Tag::class);
 
         $this->assertTrue($reflectionClass->implementsInterface(TagInterface::class));
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data
+     *
+     * @param mixed $content
+     */
+    public function testConstructorRejectsInvalidContent($content)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        new Tag($content);
     }
 
     public function testConstructorSetsValues()


### PR DESCRIPTION
This PR

* [x] asserts that non-string values are rejected by the constructor of `Component\Video\Tag`
* [x] rejects non-string values
