### PR TITLE
Fix: Reject non-string values in Component\Video\Tag

### DIFF
--- a/src/Component/Video/Uploader.php
+++ b/src/Component/Video/Uploader.php
@@ -9,6 +9,9 @@
 
 namespace Refinery29\Sitemap\Component\Video;
 
+use Assert\Assertion;
+use InvalidArgumentException;
+
 final class Uploader implements UploaderInterface
 {
     /**
@@ -23,9 +26,13 @@ final class Uploader implements UploaderInterface
 
     /**
      * @param string $name
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($name)
     {
+        Assertion::string($name);
+
         $this->name = $name;
     }
 
@@ -42,10 +49,14 @@ final class Uploader implements UploaderInterface
     /**
      * @param string $info
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withInfo($info)
     {
+        Assertion::string($info);
+
         $instance = clone $this;
 
         $instance->info = $info;

--- a/test/Unit/Component/Video/UploaderTest.php
+++ b/test/Unit/Component/Video/UploaderTest.php
@@ -9,6 +9,7 @@
 
 namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
+use InvalidArgumentException;
 use Refinery29\Sitemap\Component\Video\Uploader;
 use Refinery29\Sitemap\Component\Video\UploaderInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
@@ -39,6 +40,18 @@ class UploaderTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($uploader->info());
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data
+     *
+     * @param mixed $name
+     */
+    public function testConstructorRejectsInvalidName($name)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        new Uploader($name);
+    }
+
     public function testConstructorSetsValue()
     {
         $faker = $this->getFaker();
@@ -48,6 +61,20 @@ class UploaderTest extends \PHPUnit_Framework_TestCase
         $uploader = new Uploader($name);
 
         $this->assertSame($name, $uploader->name());
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data
+     *
+     * @param mixed $info
+     */
+    public function testWithInfoRejectsInvalidInfo($info)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $uploader = new Uploader($this->getFaker()->url);
+
+        $uploader->withInfo($info);
     }
 
     public function testWithInfoClonesObjectAndSetsValue()


### PR DESCRIPTION
This PR

* [x] asserts that non-string values are rejected
* [x] rejects non-string values
