### PR TITLE
Fix: Remove docblock

### DIFF
--- a/src/Component/Video/Tag.php
+++ b/src/Component/Video/Tag.php
@@ -31,9 +31,6 @@ final class Tag implements TagInterface
         $this->content = $content;
     }
 
-    /**
-     * @return string
-     */
     public function content()
     {
         return $this->content;


### PR DESCRIPTION
This PR

* [x] removes a docblock already defined in the interface 
