### PR TITLE
Fix: Reject invalid URLs in Component\Sitemap

### DIFF
--- a/src/Component/Sitemap.php
+++ b/src/Component/Sitemap.php
@@ -9,7 +9,9 @@
 
 namespace Refinery29\Sitemap\Component;
 
+use Assert\Assertion;
 use DateTimeInterface;
+use InvalidArgumentException;
 
 final class Sitemap implements SitemapInterface
 {
@@ -25,9 +27,13 @@ final class Sitemap implements SitemapInterface
 
     /**
      * @param string $location
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($location)
     {
+        Assertion::url($location);
+
         $this->location = $location;
     }
 

--- a/test/Unit/Component/SitemapTest.php
+++ b/test/Unit/Component/SitemapTest.php
@@ -9,6 +9,7 @@
 
 namespace Refinery29\Sitemap\Test\Unit\Component;
 
+use InvalidArgumentException;
 use Refinery29\Sitemap\Component\Sitemap;
 use Refinery29\Sitemap\Component\SitemapInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
@@ -40,6 +41,18 @@ class SitemapTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($location, $sitemap->location());
         $this->assertNull($sitemap->lastModified());
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidUrl::data
+     *
+     * @param mixed $location
+     */
+    public function testConstructorRejectsInvalidLocation($location)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        new Sitemap($location);
     }
 
     public function testConstructorSetsLocation()


### PR DESCRIPTION
This PR

* [x] asserts that the constructor of `Component\Sitemap` rejects invalid URLs
* [x] rejects invalid URLs