### PR TITLE
Fix: Do not worry about duplication locations

### DIFF
--- a/src/Component/SitemapIndex.php
+++ b/src/Component/SitemapIndex.php
@@ -28,12 +28,6 @@ final class SitemapIndex implements SitemapIndexInterface
     {
         Assertion::allIsInstanceOf($sitemaps, SitemapInterface::class);
 
-        $locations = array_map(function (SitemapInterface $sitemap) {
-            return $sitemap->location();
-        }, $sitemaps);
-
-        Assertion::same(array_unique($locations), $locations);
-
         $this->sitemaps = $sitemaps;
     }
 

--- a/test/Unit/Component/SitemapIndexTest.php
+++ b/test/Unit/Component/SitemapIndexTest.php
@@ -54,8 +54,6 @@ class SitemapIndexTest extends \PHPUnit_Framework_TestCase
     {
         $faker = $this->getFaker();
 
-        $location = $faker->url;
-
         $values = [
             $faker->words(),
             [
@@ -63,11 +61,6 @@ class SitemapIndexTest extends \PHPUnit_Framework_TestCase
                 $this->getSitemapMock(),
                 new stdClass(),
             ],
-            [
-                $this->getSitemapMock($location),
-                $this->getSitemapMock($location),
-            ],
-
         ];
 
         foreach ($values as $value) {
@@ -91,22 +84,10 @@ class SitemapIndexTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param string|null $location
-     *
      * @return \PHPUnit_Framework_MockObject_MockObject|SitemapInterface
      */
-    private function getSitemapMock($location = null)
+    private function getSitemapMock()
     {
-        $location = $location ?: $this->getFaker()->unique()->url;
-
-        $sitemap = $this->getMockBuilder(SitemapInterface::class)->getMock();
-
-        $sitemap
-            ->expects($this->any())
-            ->method('location')
-            ->willReturn($location)
-        ;
-
-        return $sitemap;
+        return $this->getMockBuilder(SitemapInterface::class)->getMock();
     }
 }


### PR DESCRIPTION
This PR

* [x] removes assertions that locations of sitemaps are unique

:information_desk_person: Google doesn't say anything about that being invalid, so we shouldn't either. Of course it doesn't make sense to add the same location twice, but that should be obvious. This is consistent with `UrlSet`s, we don't care if the same location is added there, too.
