### PR TITLE
Fix: Remove arguments

### DIFF
--- a/src/Component/Url.php
+++ b/src/Component/Url.php
@@ -54,17 +54,11 @@ final class Url implements UrlInterface
     private $videos = [];
 
     /**
-     * @param string                 $location
-     * @param DateTimeInterface|null $lastModified
-     * @param string|null            $changeFrequency
-     * @param string|null            $priority
+     * @param string $location
      */
-    public function __construct($location, DateTimeInterface $lastModified = null, $changeFrequency = null, $priority = null)
+    public function __construct($location)
     {
         $this->location = $location;
-        $this->lastModified = $lastModified;
-        $this->changeFrequency = $changeFrequency;
-        $this->priority = $priority;
     }
 
     public function location()


### PR DESCRIPTION
This PR

* [x] removes arguments from a constructor

Follows #70.

:person_with_pouting_face: Ha!
