### PR TITLE
Fix: Add constants for minimum and maximum priority

### DIFF
--- a/src/Component/UrlInterface.php
+++ b/src/Component/UrlInterface.php
@@ -13,11 +13,14 @@ use DateTimeInterface;
 
 /**
  * @link https://support.google.com/webmasters/answer/183668?hl=en
+ * @link http://www.sitemaps.org/protocol.html#xmlTagDefinitions
  */
 interface UrlInterface
 {
     /**
      * Constants for change frequencies.
+     *
+     * @link http://www.sitemaps.org/protocol.html#xmlTagDefinitions
      */
     const CHANGE_FREQUENCY_ALWAYS = 'always';
     const CHANGE_FREQUENCY_HOURLY = 'hourly';
@@ -26,6 +29,14 @@ interface UrlInterface
     const CHANGE_FREQUENCY_MONTHLY = 'monthly';
     const CHANGE_FREQUENCY_YEARLY = 'yearly';
     const CHANGE_FREQUENCY_NEVER = 'never';
+
+    /**
+     * Constants for minimum and maximum priority.
+     *
+     * @link http://www.sitemaps.org/protocol.html#xmlTagDefinitions
+     */
+    const PRIORITY_MIN = 0.0;
+    const PRIORITY_MAX = 1.0;
 
     /**
      * Constant for maximum number of images.

--- a/test/Unit/Component/UrlInterfaceTest.php
+++ b/test/Unit/Component/UrlInterfaceTest.php
@@ -22,5 +22,8 @@ class UrlInterfaceTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('monthly', UrlInterface::CHANGE_FREQUENCY_MONTHLY);
         $this->assertSame('yearly', UrlInterface::CHANGE_FREQUENCY_YEARLY);
         $this->assertSame('never', UrlInterface::CHANGE_FREQUENCY_NEVER);
+
+        $this->assertSame(0.0, UrlInterface::PRIORITY_MIN);
+        $this->assertSame(1.0, UrlInterface::PRIORITY_MAX);
     }
 }


### PR DESCRIPTION
This PR

* [x] adds constants for minimum and maximum priorities 