### PR TITLE
Fix: Reject invalid values from Component\Url

### DIFF
--- a/src/Component/Url.php
+++ b/src/Component/Url.php
@@ -55,9 +55,13 @@ final class Url implements UrlInterface
 
     /**
      * @param string $location
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($location)
     {
+        Assertion::url($location);
+
         $this->location = $location;
     }
 
@@ -113,10 +117,24 @@ final class Url implements UrlInterface
     /**
      * @param string $changeFrequency
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withChangeFrequency($changeFrequency)
     {
+        $choices = [
+            UrlInterface::CHANGE_FREQUENCY_ALWAYS,
+            UrlInterface::CHANGE_FREQUENCY_HOURLY,
+            UrlInterface::CHANGE_FREQUENCY_DAILY,
+            UrlInterface::CHANGE_FREQUENCY_WEEKLY,
+            UrlInterface::CHANGE_FREQUENCY_MONTHLY,
+            UrlInterface::CHANGE_FREQUENCY_YEARLY,
+            UrlInterface::CHANGE_FREQUENCY_NEVER,
+        ];
+
+        Assertion::choice($changeFrequency, $choices);
+
         $instance = clone $this;
 
         $instance->changeFrequency = $changeFrequency;
@@ -127,10 +145,17 @@ final class Url implements UrlInterface
     /**
      * @param string $priority
      *
+     * @throws InvalidArgumentException
+     *
      * @return static
      */
     public function withPriority($priority)
     {
+        Assertion::float($priority);
+        Assertion::greaterOrEqualThan($priority, UrlInterface::PRIORITY_MIN);
+        Assertion::lessOrEqualThan($priority, UrlInterface::PRIORITY_MAX);
+        Assertion::same($priority, round($priority, 2));
+
         $instance = clone $this;
 
         $instance->priority = $priority;

--- a/test/Unit/Component/UrlTest.php
+++ b/test/Unit/Component/UrlTest.php
@@ -54,6 +54,18 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $url->videos());
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidUrl::data
+     *
+     * @param mixed $location
+     */
+    public function testConstructorRejectsInvalidLocation($location)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        new Url($location);
+    }
+
     public function testConstructorSetsValue()
     {
         $location = $this->getFaker()->url;
@@ -79,6 +91,44 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $this->assertNotSame($lastModified, $instance->lastModified());
     }
 
+    /**
+     * @dataProvider providerInvalidChangeFrequency
+     *
+     * @param mixed $changeFrequency
+     */
+    public function testWithChangeFrequencyRejectsInvalidChangeFrequency($changeFrequency)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $url = new Url($this->getFaker()->url);
+
+        $url->withChangeFrequency($changeFrequency);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidChangeFrequency()
+    {
+        $faker = $this->getFaker();
+
+        $values = [
+            null,
+            $faker->boolean(),
+            $faker->words,
+            $faker->randomNumber(),
+            $faker->randomFloat(),
+            $faker->sentence(),
+            new stdClass(),
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
+    }
+
     public function testWithChangeFrequencyClonesObjectAndSetsValue()
     {
         $faker = $this->getFaker();
@@ -100,6 +150,45 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Url::class, $instance);
         $this->assertNotSame($url, $instance);
         $this->assertSame($changeFrequency, $instance->changeFrequency());
+    }
+
+    /**
+     * @dataProvider providerInvalidPriority
+     *
+     * @param mixed $priority
+     */
+    public function testWithPriorityRejectsInvalidPriority($priority)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $url = new Url($this->getFaker()->url);
+
+        $url->withPriority($priority);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidPriority()
+    {
+        $faker = $this->getFaker();
+
+        $values = [
+            null,
+            $faker->boolean(),
+            $faker->words,
+            $faker->sentence(),
+            UrlInterface::PRIORITY_MIN - 0.1,
+            UrlInterface::PRIORITY_MAX + 0.1,
+            0.123456,
+            new stdClass(),
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
     }
 
     public function testWithPriorityClonesObjectAndSetsValue()


### PR DESCRIPTION
This PR

* [x] asserts that invalid values are rejected by `Component\Url`
* [x] rejects invalid values
