### PR TITLE
Fix: Update docblock

### DIFF
--- a/test/Unit/Component/Video/VideoTest.php
+++ b/test/Unit/Component/Video/VideoTest.php
@@ -536,6 +536,8 @@ class VideoTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider providerInvalidCategory
+     *
+     * @param mixed $category
      */
     public function testWithCategoryRejectsInvalidValue($category)
     {


### PR DESCRIPTION
This PR

* [x] adds a parameter missing from a docblock 
