### PR TITLE
Fix: Reject priorities with precision greater than 1

### DIFF
--- a/src/Component/Url.php
+++ b/src/Component/Url.php
@@ -154,7 +154,7 @@ final class Url implements UrlInterface
         Assertion::float($priority);
         Assertion::greaterOrEqualThan($priority, UrlInterface::PRIORITY_MIN);
         Assertion::lessOrEqualThan($priority, UrlInterface::PRIORITY_MAX);
-        Assertion::same($priority, round($priority, 2));
+        Assertion::same($priority, round($priority, 1));
 
         $instance = clone $this;
 

--- a/test/Unit/Component/UrlTest.php
+++ b/test/Unit/Component/UrlTest.php
@@ -180,7 +180,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             $faker->sentence(),
             UrlInterface::PRIORITY_MIN - 0.1,
             UrlInterface::PRIORITY_MAX + 0.1,
-            0.123456,
+            0.12,
             new stdClass(),
         ];
 

--- a/test/Unit/Component/UrlTest.php
+++ b/test/Unit/Component/UrlTest.php
@@ -196,7 +196,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $priority = $faker->randomFloat(
-            2,
+            1,
             0.0,
             1.0
         );


### PR DESCRIPTION
This PR

* [x] asserts that priorities with precision greater than `1` are rejected
* [x] rejects priorities with precision greater than `1`
* [x] fixes a test using priorities with precision greater than `1`

Follows #70.
