### PR TITLE
Fix: Format priority, not 2

### DIFF
--- a/src/Writer/UrlWriter.php
+++ b/src/Writer/UrlWriter.php
@@ -102,7 +102,7 @@ class UrlWriter
         }
 
         $xmlWriter->startElement('priority');
-        $xmlWriter->text(number_format(2, $priority));
+        $xmlWriter->text(number_format($priority, 1));
         $xmlWriter->endElement();
     }
 

--- a/test/Integration/Writer/UrlSetWriterTest.php
+++ b/test/Integration/Writer/UrlSetWriterTest.php
@@ -137,6 +137,7 @@ XML;
         ;
 
         $url = $url
+            ->withPriority(0.8)
             ->withImages([
                 $image,
                 $anotherImage,
@@ -161,6 +162,7 @@ XML;
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
     <url>
         <loc>http://www.example.com/foo.html</loc>
+        <priority>0.8</priority>
         <image:image>
             <image:loc>http://example.com/image.jpg</image:loc>
             <image:caption>Dogs playing poker</image:caption>

--- a/test/Unit/Writer/UrlWriterTest.php
+++ b/test/Unit/Writer/UrlWriterTest.php
@@ -95,7 +95,7 @@ class UrlWriterTest extends AbstractTestCase
         $this->expectToWriteElement($xmlWriter, 'loc', $location);
         $this->expectToWriteElement($xmlWriter, 'lastmod', $lastModified->format('c'));
         $this->expectToWriteElement($xmlWriter, 'changefreq', $changeFrequency);
-        $this->expectToWriteElement($xmlWriter, 'priority', number_format(2, $priority));
+        $this->expectToWriteElement($xmlWriter, 'priority', number_format($priority, 1));
 
         $this->expectToEndElement($xmlWriter);
 


### PR DESCRIPTION
This PR

* [x] asserts that we actually write the priority as expected
* [x] formats the priority, not `2`
