### PR TITLE
Fix: Reject blank strings

### DIFF
--- a/src/Component/Image/Image.php
+++ b/src/Component/Image/Image.php
@@ -86,6 +86,7 @@ final class Image implements ImageInterface
     public function withTitle($title)
     {
         Assertion::string($title);
+        Assertion::notBlank($title);
 
         $instance = clone $this;
 
@@ -104,6 +105,7 @@ final class Image implements ImageInterface
     public function withCaption($caption)
     {
         Assertion::string($caption);
+        Assertion::notBlank($caption);
 
         $instance = clone $this;
 
@@ -122,6 +124,7 @@ final class Image implements ImageInterface
     public function withGeoLocation($geoLocation)
     {
         Assertion::string($geoLocation);
+        Assertion::notBlank($geoLocation);
 
         $instance = clone $this;
 
@@ -140,6 +143,7 @@ final class Image implements ImageInterface
     public function withLicence($licence)
     {
         Assertion::string($licence);
+        Assertion::notBlank($licence);
 
         $instance = clone $this;
 

--- a/src/Component/News/News.php
+++ b/src/Component/News/News.php
@@ -60,6 +60,7 @@ final class News implements NewsInterface
     public function __construct(PublicationInterface $publication, DateTimeInterface $publicationDate, $title)
     {
         Assertion::string($title);
+        Assertion::notBlank($title);
 
         $this->publication = $publication;
         $this->publicationDate = $publicationDate;
@@ -160,6 +161,7 @@ final class News implements NewsInterface
     public function withKeywords(array $keywords)
     {
         Assertion::allString($keywords);
+        Assertion::allNotBlank($keywords);
 
         $instance = clone $this;
 
@@ -178,6 +180,7 @@ final class News implements NewsInterface
     public function withStockTickers(array $stockTickers)
     {
         Assertion::allString($stockTickers);
+        Assertion::allNotBlank($stockTickers);
         Assertion::lessOrEqualThan(count($stockTickers), NewsInterface::STOCK_TICKERS_MAX_COUNT);
 
         $instance = clone $this;

--- a/src/Component/News/Publication.php
+++ b/src/Component/News/Publication.php
@@ -33,7 +33,9 @@ final class Publication implements PublicationInterface
     public function __construct($name, $language)
     {
         Assertion::string($name);
+        Assertion::notBlank($name);
         Assertion::string($language);
+        Assertion::notBlank($language);
 
         $this->name = $name;
         $this->language = $language;

--- a/src/Component/Video/GalleryLocation.php
+++ b/src/Component/Video/GalleryLocation.php
@@ -56,6 +56,7 @@ final class GalleryLocation implements GalleryLocationInterface
     public function withTitle($title)
     {
         Assertion::string($title);
+        Assertion::notBlank($title);
 
         $instance = clone $this;
 

--- a/src/Component/Video/Restriction.php
+++ b/src/Component/Video/Restriction.php
@@ -61,6 +61,7 @@ final class Restriction implements RestrictionInterface
     public function withCountryCodes(array $countryCodes)
     {
         Assertion::allString($countryCodes);
+        Assertion::allNotBlank($countryCodes);
 
         $instance = clone $this;
 

--- a/src/Component/Video/Tag.php
+++ b/src/Component/Video/Tag.php
@@ -27,6 +27,7 @@ final class Tag implements TagInterface
     public function __construct($content)
     {
         Assertion::string($content);
+        Assertion::notBlank($content);
 
         $this->content = $content;
     }

--- a/src/Component/Video/Uploader.php
+++ b/src/Component/Video/Uploader.php
@@ -32,6 +32,7 @@ final class Uploader implements UploaderInterface
     public function __construct($name)
     {
         Assertion::string($name);
+        Assertion::notBlank($name);
 
         $this->name = $name;
     }
@@ -56,6 +57,7 @@ final class Uploader implements UploaderInterface
     public function withInfo($info)
     {
         Assertion::string($info);
+        Assertion::notBlank($info);
 
         $instance = clone $this;
 

--- a/test/Unit/Component/Image/ImageTest.php
+++ b/test/Unit/Component/Image/ImageTest.php
@@ -82,6 +82,22 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $image->withTitle($title);
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $title
+     */
+    public function testWithTitleRejectsEmptyString($title)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $location = $this->getFaker()->url;
+
+        $image = new Image($location);
+
+        $image->withTitle($title);
+    }
+
     public function testWithTitleClonesObjectAndSetsValue()
     {
         $faker = $this->getFaker();
@@ -103,6 +119,22 @@ class ImageTest extends \PHPUnit_Framework_TestCase
      * @param mixed $caption
      */
     public function testWithCaptionRejectsInvalidValue($caption)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $location = $this->getFaker()->url;
+
+        $image = new Image($location);
+
+        $image->withCaption($caption);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $caption
+     */
+    public function testWithCaptionRejectsEmptyString($caption)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
@@ -144,6 +176,22 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $image->withGeoLocation($geoLocation);
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $geoLocation
+     */
+    public function testWithGeoLocationRejectsBlankString($geoLocation)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $location = $this->getFaker()->url;
+
+        $image = new Image($location);
+
+        $image->withGeoLocation($geoLocation);
+    }
+
     public function testWithGeoLocationClonesObjectAndSetsValue()
     {
         $faker = $this->getFaker();
@@ -165,6 +213,22 @@ class ImageTest extends \PHPUnit_Framework_TestCase
      * @param mixed $licence
      */
     public function testWithLicenceRejectsInvalidValue($licence)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $location = $this->getFaker()->url;
+
+        $image = new Image($location);
+
+        $image->withLicence($licence);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $licence
+     */
+    public function testWithLicenceRejectsBlankString($licence)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 

--- a/test/Unit/Component/News/NewsTest.php
+++ b/test/Unit/Component/News/NewsTest.php
@@ -74,6 +74,24 @@ class NewsTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $title
+     */
+    public function testConstructorRejectsBlankTitle($title)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        new News(
+            $this->getPublicationMock(),
+            $faker->dateTime,
+            $title
+        );
+    }
+
     public function testConstructorSetsValues()
     {
         $faker = $this->getFaker();
@@ -222,6 +240,32 @@ class NewsTest extends \PHPUnit_Framework_TestCase
         $news->withKeywords($keywords);
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $keyword
+     */
+    public function testWithKeywordsRejectsBlankValues($keyword)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $keywords = [
+            $faker->word,
+            $faker->word,
+            $keyword,
+        ];
+
+        $news = new News(
+            $this->getPublicationMock(),
+            $faker->dateTime,
+            $faker->sentence()
+        );
+
+        $news->withKeywords($keywords);
+    }
+
     public function testWithKeywordsClonesObjectAndSetsValue()
     {
         $faker = $this->getFaker();
@@ -247,6 +291,32 @@ class NewsTest extends \PHPUnit_Framework_TestCase
      * @param mixed $stockTicker
      */
     public function testWithStockTickersRejectsInvalidValues($stockTicker)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $stockTickers = [
+            $faker->word,
+            $faker->word,
+            $stockTicker,
+        ];
+
+        $news = new News(
+            $this->getPublicationMock(),
+            $faker->dateTime,
+            $faker->sentence()
+        );
+
+        $news->withStockTickers($stockTickers);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $stockTicker
+     */
+    public function testWithStockTickersRejectsBlankValues($stockTicker)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 

--- a/test/Unit/Component/News/PublicationTest.php
+++ b/test/Unit/Component/News/PublicationTest.php
@@ -51,11 +51,45 @@ class PublicationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $name
+     */
+    public function testConstructorRejectsBlankName($name)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $language = $this->getFaker()->languageCode;
+
+        new Publication(
+            $name,
+            $language
+        );
+    }
+
+    /**
      * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
      * @param mixed $language
      */
     public function testConstructorRejectsInvalidLanguage($language)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $name = $this->getFaker()->sentence();
+
+        new Publication(
+            $name,
+            $language
+        );
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $language
+     */
+    public function testConstructorRejectsBlankLanguage($language)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 

--- a/test/Unit/Component/Video/GalleryLocationTest.php
+++ b/test/Unit/Component/Video/GalleryLocationTest.php
@@ -79,6 +79,22 @@ class GalleryLocationTest extends \PHPUnit_Framework_TestCase
         $galleryLocation->withTitle($title);
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $title
+     */
+    public function testWithTitleRejectsBlankString($title)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $location = $this->getFaker()->url;
+
+        $galleryLocation = new GalleryLocation($location);
+
+        $galleryLocation->withTitle($title);
+    }
+
     public function testWithTitleClonesObjectAndSetsValue()
     {
         $faker = $this->getFaker();

--- a/test/Unit/Component/Video/RestrictionTest.php
+++ b/test/Unit/Component/Video/RestrictionTest.php
@@ -112,6 +112,31 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
         $restriction->withCountryCodes($countryCodes);
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $countryCode
+     */
+    public function testWithCountryCodeRejectsBlankCountryCodes($countryCode)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $countryCodes = [
+            $faker->countryCode,
+            $countryCode,
+        ];
+
+        $restriction = new Restriction(
+            $faker->randomElement([
+            RestrictionInterface::RELATIONSHIP_ALLOW,
+            RestrictionInterface::RELATIONSHIP_DENY,
+        ]));
+
+        $restriction->withCountryCodes($countryCodes);
+    }
+
     public function testWithCountryCodesClonesObjectAndSetsValue()
     {
         $faker = $this->getFaker();

--- a/test/Unit/Component/Video/TagTest.php
+++ b/test/Unit/Component/Video/TagTest.php
@@ -38,7 +38,19 @@ class TagTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed $content
      */
-    public function testConstructorRejectsInvalidContent($content)
+    public function testConstructorRejectsInvalidValue($content)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        new Tag($content);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $content
+     */
+    public function testConstructorRejectsBlankString($content)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 

--- a/test/Unit/Component/Video/UploaderTest.php
+++ b/test/Unit/Component/Video/UploaderTest.php
@@ -52,6 +52,18 @@ class UploaderTest extends \PHPUnit_Framework_TestCase
         new Uploader($name);
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $name
+     */
+    public function testConstructorRejectsBlankString($name)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        new Uploader($name);
+    }
+
     public function testConstructorSetsValue()
     {
         $faker = $this->getFaker();
@@ -69,6 +81,20 @@ class UploaderTest extends \PHPUnit_Framework_TestCase
      * @param mixed $info
      */
     public function testWithInfoRejectsInvalidInfo($info)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $uploader = new Uploader($this->getFaker()->url);
+
+        $uploader->withInfo($info);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $info
+     */
+    public function testWithInfoRejectsBlankString($info)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 


### PR DESCRIPTION
This PR

* [x] asserts that blank strings are rejected
* [x] rejects blank strings
