### PR TITLE
Fix: Use consistent naming for test methods

### DIFF
--- a/test/Unit/Component/SitemapTest.php
+++ b/test/Unit/Component/SitemapTest.php
@@ -48,7 +48,7 @@ class SitemapTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed $location
      */
-    public function testConstructorRejectsInvalidLocation($location)
+    public function testConstructorRejectsInvalidValue($location)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 

--- a/test/Unit/Component/UrlTest.php
+++ b/test/Unit/Component/UrlTest.php
@@ -59,7 +59,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed $location
      */
-    public function testConstructorRejectsInvalidLocation($location)
+    public function testConstructorRejectsInvalidValue($location)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
@@ -96,7 +96,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed $changeFrequency
      */
-    public function testWithChangeFrequencyRejectsInvalidChangeFrequency($changeFrequency)
+    public function testWithChangeFrequencyRejectsInvalidValue($changeFrequency)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
@@ -157,7 +157,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed $priority
      */
-    public function testWithPriorityRejectsInvalidPriority($priority)
+    public function testWithPriorityRejectsInvalidValue($priority)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 

--- a/test/Unit/Component/Video/GalleryLocationTest.php
+++ b/test/Unit/Component/Video/GalleryLocationTest.php
@@ -45,7 +45,7 @@ class GalleryLocationTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed $location
      */
-    public function testConstructorRejectsInvalidLocation($location)
+    public function testConstructorRejectsInvalidValue($location)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 

--- a/test/Unit/Component/Video/PlatformTest.php
+++ b/test/Unit/Component/Video/PlatformTest.php
@@ -49,7 +49,7 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed $relationship
      */
-    public function testConstructorRejectsInvalidRelationship($relationship)
+    public function testConstructorRejectsInvalidValue($relationship)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 

--- a/test/Unit/Component/Video/PriceTest.php
+++ b/test/Unit/Component/Video/PriceTest.php
@@ -110,7 +110,7 @@ class PriceTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed $type
      */
-    public function testWithTypeRejectsInvalidType($type)
+    public function testWithTypeRejectsInvalidValue($type)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
@@ -167,7 +167,7 @@ class PriceTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed $resolution
      */
-    public function testWithResolutionRejectsInvalidResolution($resolution)
+    public function testWithResolutionRejectsInvalidValue($resolution)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 

--- a/test/Unit/Component/Video/RestrictionTest.php
+++ b/test/Unit/Component/Video/RestrictionTest.php
@@ -51,7 +51,7 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed $restriction
      */
-    public function testConstructorRejectsInvalidRestriction($restriction)
+    public function testConstructorRejectsInvalidValue($restriction)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 

--- a/test/Unit/Component/Video/UploaderTest.php
+++ b/test/Unit/Component/Video/UploaderTest.php
@@ -45,7 +45,7 @@ class UploaderTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed $name
      */
-    public function testConstructorRejectsInvalidName($name)
+    public function testConstructorRejectsInvalidValue($name)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
@@ -80,7 +80,7 @@ class UploaderTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed $info
      */
-    public function testWithInfoRejectsInvalidInfo($info)
+    public function testWithInfoRejectsInvalidValue($info)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 

--- a/test/Unit/Component/Video/VideoTest.php
+++ b/test/Unit/Component/Video/VideoTest.php
@@ -169,7 +169,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
      *
      * @param mixed $duration
      */
-    public function testWithDurationRejectsInvalidDuration($duration)
+    public function testWithDurationRejectsInvalidValue($duration)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 


### PR DESCRIPTION
This PR

* [x] applies consistent naming to test methods
