### PR TITLE
Fix: Extract constant for minimum view count value

### DIFF
--- a/src/Component/Video/Video.php
+++ b/src/Component/Video/Video.php
@@ -340,7 +340,7 @@ final class Video implements VideoInterface
     public function withViewCount($viewCount)
     {
         Assertion::integer($viewCount);
-        Assertion::greaterOrEqualThan($viewCount, 0);
+        Assertion::greaterOrEqualThan($viewCount, VideoInterface::VIEW_COUNT_MIN);
 
         $instance = clone $this;
 

--- a/src/Component/Video/VideoInterface.php
+++ b/src/Component/Video/VideoInterface.php
@@ -53,6 +53,11 @@ interface VideoInterface
     const RATING_MAX = 5.0;
 
     /**
+     * Constant for minimum view count value.
+     */
+    const VIEW_COUNT_MIN = 0;
+
+    /**
      * Constants for subscription requirement.
      *
      * @link https://developers.google.com/webmasters/videosearch/sitemaps#video-sitemap-tag-definitions

--- a/test/Unit/Component/Video/VideoInterfaceTest.php
+++ b/test/Unit/Component/Video/VideoInterfaceTest.php
@@ -26,6 +26,8 @@ class VideoInterfaceTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(0.0, VideoInterface::RATING_MIN);
         $this->assertSame(5.0, VideoInterface::RATING_MAX);
 
+        $this->assertSame(0, VideoInterface::VIEW_COUNT_MIN);
+
         $this->assertSame('yes', VideoInterface::REQUIRES_SUBSCRIPTION_YES);
         $this->assertSame('no', VideoInterface::REQUIRES_SUBSCRIPTION_NO);
 

--- a/test/Unit/Component/Video/VideoTest.php
+++ b/test/Unit/Component/Video/VideoTest.php
@@ -368,7 +368,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     {
         $values = [
             'foo',
-            -1,
+            VideoInterface::VIEW_COUNT_MIN - 1,
         ];
 
         foreach ($values as $value) {
@@ -382,7 +382,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     {
         $faker = $this->getFaker();
 
-        $viewCount = $faker->numberBetween(0);
+        $viewCount = $faker->numberBetween(VideoInterface::VIEW_COUNT_MIN);
 
         $video = new Video(
             $faker->url,


### PR DESCRIPTION
This PR

* [x] extracts a constant for minimum view count value

💁 Seems natural that it shouldn't be less than `0`, but a named constant is better than a magic number.
