### PR TITLE
Fix: Reject non-float values

### DIFF
--- a/src/Component/Video/Price.php
+++ b/src/Component/Video/Price.php
@@ -42,6 +42,7 @@ final class Price implements PriceInterface
      */
     public function __construct($value, $currency)
     {
+        Assertion::float($value);
         Assertion::greaterOrEqualThan($value, PriceInterface::VALUE_MIN);
 
         $this->value = $value;

--- a/test/Unit/Component/Video/PriceTest.php
+++ b/test/Unit/Component/Video/PriceTest.php
@@ -56,7 +56,7 @@ class PriceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidValue
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidFloat::data()
      *
      * @param mixed $value
      */
@@ -72,21 +72,18 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidValue()
+    public function testConstructorRejectsTooSmallValue()
     {
-        $invalidValues = [
-            'foo',
-            PriceInterface::VALUE_MIN - 0.01,
-        ];
+        $this->setExpectedException(InvalidArgumentException::class);
 
-        foreach ($invalidValues as $value) {
-            yield [
-                $value,
-            ];
-        }
+        $value = PriceInterface::VALUE_MIN - 0.01;
+
+        $faker = $this->getFaker();
+
+        new Price(
+            $value,
+            $faker->currencyCode
+        );
     }
 
     public function testConstructorSetsValues()


### PR DESCRIPTION
This PR

* [x] asserts that non-float values are rejected
* [x] rejects non-float values
