### PR TITLE
Fix: Use constant for minimum price

### DIFF
--- a/test/Unit/Component/Video/PriceTest.php
+++ b/test/Unit/Component/Video/PriceTest.php
@@ -47,7 +47,7 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $price = new Price(
-            $faker->randomFloat(2, 0.01),
+            $faker->randomFloat(2, PriceInterface::VALUE_MIN),
             $faker->currencyCode
         );
 
@@ -93,7 +93,7 @@ class PriceTest extends \PHPUnit_Framework_TestCase
     {
         $faker = $this->getFaker();
 
-        $value = $faker->randomFloat(2, 0.01);
+        $value = $faker->randomFloat(2, PriceInterface::VALUE_MIN);
         $currency = $faker->currencyCode;
 
         $price = new Price(
@@ -117,7 +117,7 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $price = new Price(
-            $faker->randomFloat(2, 0.01),
+            $faker->randomFloat(2, PriceInterface::VALUE_MIN),
             $faker->currencyCode
         );
 
@@ -151,7 +151,7 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $price = new Price(
-            $faker->randomFloat(2, 0.01),
+            $faker->randomFloat(2, PriceInterface::VALUE_MIN),
             $faker->currencyCode
         );
 
@@ -174,7 +174,7 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $price = new Price(
-            $faker->randomFloat(2, 0.01),
+            $faker->randomFloat(2, PriceInterface::VALUE_MIN),
             $faker->currencyCode
         );
 
@@ -208,7 +208,7 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $price = new Price(
-            $faker->randomFloat(2, 0.01),
+            $faker->randomFloat(2, PriceInterface::VALUE_MIN),
             $faker->currencyCode
         );
 

--- a/test/Unit/Writer/Video/PriceWriterTest.php
+++ b/test/Unit/Writer/Video/PriceWriterTest.php
@@ -21,7 +21,7 @@ class PriceWriterTest extends AbstractTestCase
         $faker = $this->getFaker();
 
         $currency = $faker->currencyCode;
-        $value = $faker->randomFloat(2, 0.01);
+        $value = $faker->randomFloat(2, PriceInterface::VALUE_MIN);
 
         $price = $this->getPriceMock(
             $currency,
@@ -44,7 +44,7 @@ class PriceWriterTest extends AbstractTestCase
         $faker = $this->getFaker();
 
         $currency = $faker->currencyCode;
-        $value = $faker->randomFloat(2, 0.01);
+        $value = $faker->randomFloat(2, PriceInterface::VALUE_MIN);
         $type = $faker->randomElement([
             PriceInterface::TYPE_OWN,
             PriceInterface::TYPE_RENT,


### PR DESCRIPTION
This PR

* [x] uses the constant for price minimum value instead of magic numbers
