### PR TITLE
Fix: Increase verbosity of tests

### DIFF
--- a/src/Component/Video/VideoInterface.php
+++ b/src/Component/Video/VideoInterface.php
@@ -53,7 +53,7 @@ interface VideoInterface
     const RATING_MAX = 5.0;
 
     /**
-     * Constant for minimum view count value.
+     * Constant for view count minimum value.
      */
     const VIEW_COUNT_MIN = 0;
 

--- a/test/Unit/Component/News/NewsTest.php
+++ b/test/Unit/Component/News/NewsTest.php
@@ -112,7 +112,7 @@ class NewsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidAccess
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
      * @param mixed $access
      */
@@ -132,30 +132,13 @@ class NewsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \Generator
+     * @dataProvider providerAccess
+     *
+     * @param string $access
      */
-    public function providerInvalidAccess()
-    {
-        $values = [
-            null,
-            $this->getFaker()->sentence(),
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
-    }
-
-    public function testWithAccessClonesObjectAndSetsValue()
+    public function testWithAccessClonesObjectAndSetsValue($access)
     {
         $faker = $this->getFaker();
-
-        $access = $faker->randomElement([
-            NewsInterface::ACCESS_REGISTRATION,
-            NewsInterface::ACCESS_SUBSCRIPTION,
-        ]);
 
         $news = new News(
             $this->getPublicationMock(),
@@ -170,14 +153,59 @@ class NewsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($access, $instance->access());
     }
 
-    public function testWithGenresRejectsInvalidValues()
+    /**
+     * @return \Generator
+     */
+    public function providerAccess()
+    {
+        $values = [
+            NewsInterface::ACCESS_REGISTRATION,
+            NewsInterface::ACCESS_SUBSCRIPTION,
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $genre
+     */
+    public function testWithGenresRejectsInvalidValues($genre)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
         $genres = [
-            'foobarbaz',
+            NewsInterface::GENRE_BLOG,
+            NewsInterface::GENRE_OP_ED,
+            $genre,
+        ];
+
+        $news = new News(
+            $this->getPublicationMock(),
+            $faker->dateTime,
+            $faker->sentence()
+        );
+
+        $news->withGenres($genres);
+    }
+
+    public function testWithGenresRejectsUnknownValues()
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $genres = [
+            NewsInterface::GENRE_BLOG,
+            NewsInterface::GENRE_OP_ED,
+            $faker->sentence(),
         ];
 
         $news = new News(

--- a/test/Unit/Component/UrlSetTest.php
+++ b/test/Unit/Component/UrlSetTest.php
@@ -28,41 +28,30 @@ class UrlSetTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($reflectionClass->isFinal());
     }
 
-    /**
-     * @dataProvider providerInvalidUrls
-     *
-     * @param mixed $urls
-     */
-    public function testConstructorRejectsInvalidValue($urls)
+    public function testConstructorRejectsInvalidValue()
     {
         $this->setExpectedException(InvalidArgumentException::class);
+
+        $urls = [
+            $this->getUrlMock(),
+            $this->getUrlMock(),
+            new stdClass(),
+        ];
 
         new UrlSet($urls);
     }
 
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidUrls()
+    public function testConstructorRejectsTooManyValues()
     {
-        $values = [
-            [
-                $this->getUrlMock(),
-                $this->getUrlMock(),
-                new stdClass(),
-            ],
-            array_fill(
-                0,
-                UrlSetInterface::URL_MAX_COUNT + 1,
-                $this->getUrlMock()
-            ),
-        ];
+        $this->setExpectedException(InvalidArgumentException::class);
 
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        $urls = array_fill(
+            0,
+            UrlSetInterface::URL_MAX_COUNT + 1,
+            $this->getUrlMock()
+        );
+
+        new UrlSet($urls);
     }
 
     public function testConstructorSetsValue()

--- a/test/Unit/Component/UrlTest.php
+++ b/test/Unit/Component/UrlTest.php
@@ -10,6 +10,7 @@
 namespace Refinery29\Sitemap\Test\Unit\Component;
 
 use InvalidArgumentException;
+use Refinery29\CS\Config\Refinery29;
 use Refinery29\Sitemap\Component\Image\ImageInterface;
 use Refinery29\Sitemap\Component\News\NewsInterface;
 use Refinery29\Sitemap\Component\Url;
@@ -92,7 +93,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidChangeFrequency
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
      * @param mixed $changeFrequency
      */
@@ -106,42 +107,13 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \Generator
+     * @dataProvider providerChangeFrequency
+     *
+     * @param string $changeFrequency
      */
-    public function providerInvalidChangeFrequency()
+    public function testWithChangeFrequencyClonesObjectAndSetsValue($changeFrequency)
     {
         $faker = $this->getFaker();
-
-        $values = [
-            null,
-            $faker->boolean(),
-            $faker->words,
-            $faker->randomNumber(),
-            $faker->randomFloat(),
-            $faker->sentence(),
-            new stdClass(),
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
-    }
-
-    public function testWithChangeFrequencyClonesObjectAndSetsValue()
-    {
-        $faker = $this->getFaker();
-
-        $changeFrequency = $faker->randomElement([
-            UrlInterface::CHANGE_FREQUENCY_ALWAYS,
-            UrlInterface::CHANGE_FREQUENCY_HOURLY,
-            UrlInterface::CHANGE_FREQUENCY_DAILY,
-            UrlInterface::CHANGE_FREQUENCY_WEEKLY,
-            UrlInterface::CHANGE_FREQUENCY_MONTHLY,
-            UrlInterface::CHANGE_FREQUENCY_YEARLY,
-            UrlInterface::CHANGE_FREQUENCY_NEVER,
-        ]);
 
         $url = new Url($faker->url);
 
@@ -153,7 +125,29 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidPriority
+     * @return \Generator
+     */
+    public function providerChangeFrequency()
+    {
+        $values = [
+            UrlInterface::CHANGE_FREQUENCY_ALWAYS,
+            UrlInterface::CHANGE_FREQUENCY_HOURLY,
+            UrlInterface::CHANGE_FREQUENCY_DAILY,
+            UrlInterface::CHANGE_FREQUENCY_WEEKLY,
+            UrlInterface::CHANGE_FREQUENCY_MONTHLY,
+            UrlInterface::CHANGE_FREQUENCY_YEARLY,
+            UrlInterface::CHANGE_FREQUENCY_NEVER,
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidFloat::data()
      *
      * @param mixed $priority
      */
@@ -167,21 +161,27 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider providerOutOfBoundsPriority
+     *
+     * @param mixed $priority
+     */
+    public function testWithPriorityRejectsOutOfBoundsValue($priority)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $url = new Url($this->getFaker()->url);
+
+        $url->withPriority($priority);
+    }
+
+    /**
      * @return \Generator
      */
-    public function providerInvalidPriority()
+    public function providerOutOfBoundsPriority()
     {
-        $faker = $this->getFaker();
-
         $values = [
-            null,
-            $faker->boolean(),
-            $faker->words,
-            $faker->sentence(),
             UrlInterface::PRIORITY_MIN - 0.1,
             UrlInterface::PRIORITY_MAX + 0.1,
-            0.12,
-            new stdClass(),
         ];
 
         foreach ($values as $value) {
@@ -191,15 +191,14 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testWithPriorityClonesObjectAndSetsValue()
+    /**
+     * @dataProvider providerPriority
+     *
+     * @param float $priority
+     */
+    public function testWithPriorityClonesObjectAndSetsValue($priority)
     {
         $faker = $this->getFaker();
-
-        $priority = $faker->randomFloat(
-            1,
-            0.0,
-            1.0
-        );
 
         $url = new Url($faker->url);
 
@@ -208,6 +207,28 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Url::class, $instance);
         $this->assertNotSame($url, $instance);
         $this->assertSame($priority, $instance->priority());
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerPriority()
+    {
+        $values = [
+            UrlInterface::PRIORITY_MAX,
+            UrlInterface::PRIORITY_MIN,
+            $this->getFaker()->randomFloat(
+                1,
+                UrlInterface::PRIORITY_MIN,
+                UrlInterface::PRIORITY_MAX
+            ),
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
     }
 
     /**

--- a/test/Unit/Component/Video/PlatformTest.php
+++ b/test/Unit/Component/Video/PlatformTest.php
@@ -45,7 +45,7 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidRelationship
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
      * @param mixed $relationship
      */
@@ -57,13 +57,25 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider providerRelationship
+     *
+     * @param string $relationship
+     */
+    public function testConstructorSetsValue($relationship)
+    {
+        $platform = new Platform($relationship);
+
+        $this->assertSame($relationship, $platform->relationship());
+    }
+
+    /**
      * @return \Generator
      */
-    public function providerInvalidRelationship()
+    public function providerRelationship()
     {
         $values = [
-            null,
-            $this->getFaker()->sentence(),
+            PlatformInterface::RELATIONSHIP_ALLOW,
+            PlatformInterface::RELATIONSHIP_DENY,
         ];
 
         foreach ($values as $value) {
@@ -73,35 +85,12 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testConstructorSetsValue()
-    {
-        $relationship = $this->getFaker()->randomElement([
-            PlatformInterface::RELATIONSHIP_ALLOW,
-            PlatformInterface::RELATIONSHIP_DENY,
-        ]);
-
-        $platform = new Platform($relationship);
-
-        $this->assertSame($relationship, $platform->relationship());
-    }
-
-    public function testWithTypesRejectsInvalidValues()
-    {
-        $this->setExpectedException(InvalidArgumentException::class);
-
-        $faker = $this->getFaker();
-
-        $types = $faker->words;
-
-        $platform = new Platform($faker->randomElement([
-            PlatformInterface::RELATIONSHIP_ALLOW,
-            PlatformInterface::RELATIONSHIP_DENY,
-        ]));
-
-        $platform->withTypes($types);
-    }
-
-    public function testWithTypesRejectsDuplicateValues()
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $type
+     */
+    public function testWithTypesRejectsInvalidValues($type)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
@@ -109,7 +98,8 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
 
         $types = [
             PlatformInterface::TYPE_MOBILE,
-            PlatformInterface::TYPE_MOBILE,
+            PlatformInterface::TYPE_TV,
+            $type,
         ];
 
         $platform = new Platform($faker->randomElement([
@@ -118,6 +108,68 @@ class PlatformTest extends \PHPUnit_Framework_TestCase
         ]));
 
         $platform->withTypes($types);
+    }
+
+    public function testWithTypesRejectsUnknownValues()
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $types = [
+            PlatformInterface::TYPE_MOBILE,
+            PlatformInterface::TYPE_TV,
+            $faker->sentence(),
+        ];
+
+        $platform = new Platform($faker->randomElement([
+            PlatformInterface::RELATIONSHIP_ALLOW,
+            PlatformInterface::RELATIONSHIP_DENY,
+        ]));
+
+        $platform->withTypes($types);
+    }
+
+    /**
+     * @dataProvider providerType
+     *
+     * @param string $type
+     */
+    public function testWithTypesRejectsDuplicateValues($type)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $types = [
+            $type,
+            $type,
+        ];
+
+        $platform = new Platform($faker->randomElement([
+            PlatformInterface::RELATIONSHIP_ALLOW,
+            PlatformInterface::RELATIONSHIP_DENY,
+        ]));
+
+        $platform->withTypes($types);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerType()
+    {
+        $values = [
+            PlatformInterface::TYPE_MOBILE,
+            PlatformInterface::TYPE_TV,
+            PlatformInterface::TYPE_WEB,
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
     }
 
     public function testWithTypesClonesObjectAndSetsValue()

--- a/test/Unit/Component/Video/PlayerLocationTest.php
+++ b/test/Unit/Component/Video/PlayerLocationTest.php
@@ -71,7 +71,7 @@ class PlayerLocationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidAllowEmbed
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
      * @param $allowEmbed
      */
@@ -86,14 +86,45 @@ class PlayerLocationTest extends \PHPUnit_Framework_TestCase
         $playerLocation->withAllowEmbed($allowEmbed);
     }
 
+    public function testWithAllowEmbedRejectsUnknownValues()
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $allowEmbed = $faker->sentence();
+
+        $playerLocation = new PlayerLocation($faker->url);
+
+        $playerLocation->withAllowEmbed($allowEmbed);
+    }
+
+    /**
+     * @dataProvider providerAllowEmbed
+     *
+     * @param string $allowEmbed
+     */
+    public function testWithAllowEmbedClonesObjectAndSetsValue($allowEmbed)
+    {
+        $faker = $this->getFaker();
+
+        $playerLocation = new PlayerLocation($faker->url);
+
+        $instance = $playerLocation->withAllowEmbed($allowEmbed);
+
+        $this->assertInstanceOf(PlayerLocation::class, $instance);
+        $this->assertNotSame($playerLocation, $instance);
+        $this->assertSame($allowEmbed, $instance->allowEmbed());
+    }
+
     /**
      * @return \Generator
      */
-    public function providerInvalidAllowEmbed()
+    public function providerAllowEmbed()
     {
         $values = [
-            null,
-            $this->getFaker()->sentence(),
+            PlayerLocationInterface::ALLOW_EMBED_NO,
+            PlayerLocationInterface::ALLOW_EMBED_YES,
         ];
 
         foreach ($values as $value) {
@@ -103,22 +134,22 @@ class PlayerLocationTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testWithAllowEmbedClonesObjectAndSetsValue()
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $autoPlay
+     */
+    public function testWithAutoPlayRejectsInvalidValue($autoPlay)
     {
         $faker = $this->getFaker();
 
-        $allowEmbed = $faker->randomElement([
-            PlayerLocationInterface::ALLOW_EMBED_NO,
-            PlayerLocationInterface::ALLOW_EMBED_YES,
-        ]);
-
         $playerLocation = new PlayerLocation($faker->url);
 
-        $instance = $playerLocation->withAllowEmbed($allowEmbed);
+        $instance = $playerLocation->withAutoPlay($autoPlay);
 
         $this->assertInstanceOf(PlayerLocation::class, $instance);
         $this->assertNotSame($playerLocation, $instance);
-        $this->assertSame($allowEmbed, $instance->allowEmbed());
+        $this->assertSame($autoPlay, $instance->autoPlay());
     }
 
     public function testWithAutoPlayClonesObjectAndSetsValue()

--- a/test/Unit/Component/Video/PriceTest.php
+++ b/test/Unit/Component/Video/PriceTest.php
@@ -19,15 +19,6 @@ class PriceTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 
-    public function testConstants()
-    {
-        $this->assertSame('own', PriceInterface::TYPE_OWN);
-        $this->assertSame('rent', PriceInterface::TYPE_RENT);
-
-        $this->assertSame('HD', PriceInterface::RESOLUTION_HD);
-        $this->assertSame('SD', PriceInterface::RESOLUTION_SD);
-    }
-
     public function testIsFinal()
     {
         $reflectionClass = new ReflectionClass(Price::class);
@@ -64,11 +55,9 @@ class PriceTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
-        $faker = $this->getFaker();
-
         new Price(
             $value,
-            $faker->currencyCode
+            $this->getFaker()->currencyCode
         );
     }
 
@@ -103,7 +92,7 @@ class PriceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidType
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
      * @param mixed $type
      */
@@ -121,34 +110,40 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         $price->withType($type);
     }
 
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidType()
+    public function testWithTypeRejectsUnknownValue()
     {
-        $values = [
-            null,
-            $this->getFaker()->sentence(),
-        ];
+        $this->setExpectedException(InvalidArgumentException::class);
 
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
-    }
-
-    public function testWithTypeClonesObjectAndSetsValue()
-    {
         $faker = $this->getFaker();
 
-        $type = $faker->randomElement([
-            PriceInterface::TYPE_OWN,
-            PriceInterface::TYPE_RENT,
-        ]);
+        $type = $this->getFaker()->sentence();
 
         $price = new Price(
             $faker->randomFloat(2, PriceInterface::VALUE_MIN),
+            $faker->randomFloat(
+                2,
+                PriceInterface::VALUE_MIN
+            ),
+            $faker->currencyCode
+        );
+
+        $price->withType($type);
+    }
+
+    /**
+     * @dataProvider providerType
+     *
+     * @param string $type
+     */
+    public function testWithTypeClonesObjectAndSetsValue($type)
+    {
+        $faker = $this->getFaker();
+
+        $price = new Price(
+            $faker->randomFloat(
+                2,
+                PriceInterface::VALUE_MIN
+            ),
             $faker->currencyCode
         );
 
@@ -160,7 +155,24 @@ class PriceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidResolution
+     * @return \Generator
+     */
+    public function providerType()
+    {
+        $values = [
+            PriceInterface::TYPE_OWN,
+            PriceInterface::TYPE_RENT,
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
      * @param mixed $resolution
      */
@@ -178,34 +190,36 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         $price->withResolution($resolution);
     }
 
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidResolution()
+    public function testWithResolutionRejectsUnknownValue()
     {
-        $values = [
-            null,
-            $this->getFaker()->sentence(),
-        ];
+        $this->setExpectedException(InvalidArgumentException::class);
 
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
-    }
-
-    public function testWithResolutionClonesObjectAndSetsValue()
-    {
         $faker = $this->getFaker();
 
-        $resolution = $faker->randomElement([
-            PriceInterface::RESOLUTION_HD,
-            PriceInterface::RESOLUTION_SD,
-        ]);
+        $resolution = $faker->sentence();
 
         $price = new Price(
             $faker->randomFloat(2, PriceInterface::VALUE_MIN),
+            $faker->currencyCode
+        );
+
+        $price->withResolution($resolution);
+    }
+
+    /**
+     * @dataProvider providerResolution
+     *
+     * @param string $resolution
+     */
+    public function testWithResolutionClonesObjectAndSetsValue($resolution)
+    {
+        $faker = $this->getFaker();
+
+        $price = new Price(
+            $faker->randomFloat(
+                2,
+                PriceInterface::VALUE_MIN
+            ),
             $faker->currencyCode
         );
 
@@ -214,5 +228,22 @@ class PriceTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Price::class, $instance);
         $this->assertNotSame($price, $instance);
         $this->assertSame($resolution, $instance->resolution());
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerResolution()
+    {
+        $values = [
+            PriceInterface::RESOLUTION_HD,
+            PriceInterface::RESOLUTION_SD,
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
     }
 }

--- a/test/Unit/Component/Video/RestrictionTest.php
+++ b/test/Unit/Component/Video/RestrictionTest.php
@@ -47,7 +47,7 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidRestriction
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
      * @param mixed $restriction
      */
@@ -58,14 +58,35 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
         new Restriction($restriction);
     }
 
+    public function testConstructorRejectsUnknownValue()
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $relationship = $this->getFaker()->sentence();
+
+        new Restriction($relationship);
+    }
+
+    /**
+     * @dataProvider providerRelationship
+     *
+     * @param string $relationship
+     */
+    public function testConstructorSetsValue($relationship)
+    {
+        $restriction = new Restriction($relationship);
+
+        $this->assertSame($relationship, $restriction->relationship());
+    }
+
     /**
      * @return \Generator
      */
-    public function providerInvalidRestriction()
+    public function providerRelationship()
     {
         $values = [
-            null,
-            $this->getFaker()->sentence(),
+            RestrictionInterface::RELATIONSHIP_ALLOW,
+            RestrictionInterface::RELATIONSHIP_DENY,
         ];
 
         foreach ($values as $value) {
@@ -73,18 +94,6 @@ class RestrictionTest extends \PHPUnit_Framework_TestCase
                 $value,
             ];
         }
-    }
-
-    public function testConstructorSetsValue()
-    {
-        $relationship = $this->getFaker()->randomElement([
-            RestrictionInterface::RELATIONSHIP_ALLOW,
-            RestrictionInterface::RELATIONSHIP_DENY,
-        ]);
-
-        $restriction = new Restriction($relationship);
-
-        $this->assertSame($relationship, $restriction->relationship());
     }
 
     /**

--- a/test/Unit/Component/Video/VideoTest.php
+++ b/test/Unit/Component/Video/VideoTest.php
@@ -165,7 +165,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidDuration
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidInteger::data()
      *
      * @param mixed $duration
      */
@@ -187,12 +187,33 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider providerOutOfBoundsDuration
+     *
+     * @param mixed $duration
+     */
+    public function testWithDurationRejectsOutOfBoundsValue($duration)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $video = new Video(
+            $faker->url,
+            $faker->sentence,
+            $faker->paragraphs(5, true),
+            $faker->url,
+            $this->getPlayerLocationMock()
+        );
+
+        $video->withDuration($duration);
+    }
+
+    /**
      * @return \Generator
      */
-    public function providerInvalidDuration()
+    public function providerOutOfBoundsDuration()
     {
         $values = [
-            'foo',
             VideoInterface::DURATION_LOWER_LIMIT - 1,
             VideoInterface::DURATION_LOWER_LIMIT,
             VideoInterface::DURATION_UPPER_LIMIT,
@@ -275,7 +296,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidRating
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidFloat::data()
      *
      * @param mixed $rating
      */
@@ -297,12 +318,33 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider providerOutOfBoundsRating
+     *
+     * @param mixed $rating
+     */
+    public function testWithRatingRejectsOutOfBoundsValue($rating)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $video = new Video(
+            $faker->url,
+            $faker->sentence,
+            $faker->paragraphs(5, true),
+            $faker->url,
+            $this->getPlayerLocationMock()
+        );
+
+        $video->withRating($rating);
+    }
+
+    /**
      * @return \Generator
      */
-    public function providerInvalidRating()
+    public function providerOutOfBoundsRating()
     {
         $values = [
-            'foo',
             VideoInterface::RATING_MIN - 0.1,
             VideoInterface::RATING_MAX + 0.1,
         ];
@@ -340,7 +382,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidViewCount
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidInteger::data()
      *
      * @param mixed $viewCount
      */
@@ -361,21 +403,23 @@ class VideoTest extends \PHPUnit_Framework_TestCase
         $video->withViewCount($viewCount);
     }
 
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidViewCount()
+    public function testWithViewCountRejectsNegativeValue()
     {
-        $values = [
-            'foo',
-            VideoInterface::VIEW_COUNT_MIN - 1,
-        ];
+        $this->setExpectedException(InvalidArgumentException::class);
 
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        $faker = $this->getFaker();
+
+        $viewCount = VideoInterface::VIEW_COUNT_MIN - 1;
+
+        $video = new Video(
+            $faker->url,
+            $faker->sentence,
+            $faker->paragraphs(5, true),
+            $faker->url,
+            $this->getPlayerLocationMock()
+        );
+
+        $video->withViewCount($viewCount);
     }
 
     public function testWithViewCountClonesObjectAndSetsValue()
@@ -400,7 +444,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidFamilyFriendly
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
      * @param mixed $familyFriendly
      */
@@ -421,21 +465,23 @@ class VideoTest extends \PHPUnit_Framework_TestCase
         $video->withFamilyFriendly($familyFriendly);
     }
 
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidFamilyFriendly()
+    public function testWithFamilyFriendlyRejectsUnknownValue()
     {
-        $values = [
-            'foo',
-            true,
-        ];
+        $this->setExpectedException(InvalidArgumentException::class);
 
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        $faker = $this->getFaker();
+
+        $familyFriendly = $faker->sentence();
+
+        $video = new Video(
+            $faker->url,
+            $faker->sentence,
+            $faker->paragraphs(5, true),
+            $faker->url,
+            $this->getPlayerLocationMock()
+        );
+
+        $video->withFamilyFriendly($familyFriendly);
     }
 
     public function testWithFamilyFriendlyClonesObjectAndSetsValue()
@@ -460,15 +506,21 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidTags
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
-     * @param mixed $tags
+     * @param mixed $tag
      */
-    public function testWithTagsRejectsInvalidValue($tags)
+    public function testWithTagsRejectsInvalidValue($tag)
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
         $faker = $this->getFaker();
+
+        $tags = [
+            $faker->word,
+            $faker->word,
+            $tag,
+        ];
 
         $video = new Video(
             $faker->url,
@@ -481,32 +533,27 @@ class VideoTest extends \PHPUnit_Framework_TestCase
         $video->withTags($tags);
     }
 
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidTags()
+    public function testWithTagsRejectsTooManyValues()
     {
+        $this->setExpectedException(InvalidArgumentException::class);
+
         $faker = $this->getFaker();
 
-        $values = [
-            $faker->words(),
-            [
-                $this->getTagMock(),
-                $this->getTagMock(),
-                new stdClass(),
-            ],
-            array_fill(
-                0,
-                VideoInterface::TAG_MAX_COUNT + 1,
-                $this->getTagMock()
-            ),
-        ];
+        $tags = array_fill(
+            0,
+            VideoInterface::TAG_MAX_COUNT + 1,
+            $this->getTagMock()
+        );
 
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        $video = new Video(
+            $faker->url,
+            $faker->sentence,
+            $faker->paragraphs(5, true),
+            $faker->url,
+            $this->getPlayerLocationMock()
+        );
+
+        $video->withTags($tags);
     }
 
     public function testWithTagsClonesObjectAndSetsValue()
@@ -535,7 +582,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidCategory
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
      * @param mixed $category
      */
@@ -556,30 +603,26 @@ class VideoTest extends \PHPUnit_Framework_TestCase
         $video->withCategory($category);
     }
 
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidCategory()
+    public function testWithCategoryRejectsTooLongValue()
     {
+        $this->setExpectedException(InvalidArgumentException::class);
+
         $faker = $this->getFaker();
 
-        $values = [
-            $faker->boolean(),
-            $faker->randomFloat(),
-            $faker->randomNumber(),
-            $faker->words(),
-            str_repeat(
-                'a',
-                VideoInterface::CATEGORY_MAX_LENGTH + 1
-            ),
-            new stdClass(),
-        ];
+        $category = str_repeat(
+            'a',
+            VideoInterface::CATEGORY_MAX_LENGTH + 1
+        );
 
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        $video = new Video(
+            $faker->url,
+            $faker->sentence,
+            $faker->paragraphs(5, true),
+            $faker->url,
+            $this->getPlayerLocationMock()
+        );
+
+        $video->withCategory($category);
     }
 
     public function testWithCategoryClonesObjectAndSetsValue()
@@ -624,16 +667,17 @@ class VideoTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($restriction, $instance->restriction());
     }
 
-    /**
-     * @dataProvider providerInvalidPrices
-     *
-     * @param mixed $prices
-     */
-    public function testWithPricesRejectsInvalidValue($prices)
+    public function testWithPricesRejectsInvalidValue()
     {
         $this->setExpectedException(InvalidArgumentException::class);
 
         $faker = $this->getFaker();
+
+        $prices = [
+            $this->getPriceMock(),
+            $this->getPriceMock(),
+            new stdClass(),
+        ];
 
         $video = new Video(
             $faker->url,
@@ -644,29 +688,6 @@ class VideoTest extends \PHPUnit_Framework_TestCase
         );
 
         $video->withPrices($prices);
-    }
-
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidPrices()
-    {
-        $faker = $this->getFaker();
-
-        $values = [
-            $faker->words(),
-            [
-                $this->getPriceMock(),
-                $this->getPriceMock(),
-                new stdClass(),
-            ],
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
     }
 
     public function testWithPricesClonesObjectAndSetsValue()
@@ -695,7 +716,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidRequiresSubscription
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
      * @param mixed $requiresSubscription
      */
@@ -716,31 +737,33 @@ class VideoTest extends \PHPUnit_Framework_TestCase
         $video->withRequiresSubscription($requiresSubscription);
     }
 
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidRequiresSubscription()
+    public function testWithRequiresSubscriptionRejectsUnknownValue()
     {
-        $values = [
-            'foobarbaz',
-            true,
-        ];
+        $this->setExpectedException(InvalidArgumentException::class);
 
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
-    }
-
-    public function testWithRequiresSubscriptionClonesObjectAndSetsValue()
-    {
         $faker = $this->getFaker();
 
-        $requiresSubscription = $faker->randomElement([
-            VideoInterface::REQUIRES_SUBSCRIPTION_NO,
-            VideoInterface::REQUIRES_SUBSCRIPTION_YES,
-        ]);
+        $requiresSubscription = $faker->sentence();
+
+        $video = new Video(
+            $faker->url,
+            $faker->sentence,
+            $faker->paragraphs(5, true),
+            $faker->url,
+            $this->getPlayerLocationMock()
+        );
+
+        $video->withRequiresSubscription($requiresSubscription);
+    }
+
+    /**
+     * @dataProvider providerRequiresSubscription
+     *
+     * @param string $requiresSubscription
+     */
+    public function testWithRequiresSubscriptionClonesObjectAndSetsValue($requiresSubscription)
+    {
+        $faker = $this->getFaker();
 
         $video = new Video(
             $faker->url,
@@ -755,6 +778,23 @@ class VideoTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Video::class, $instance);
         $this->assertNotSame($video, $instance);
         $this->assertSame($requiresSubscription, $instance->requiresSubscription());
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerRequiresSubscription()
+    {
+        $values = [
+            VideoInterface::REQUIRES_SUBSCRIPTION_NO,
+            VideoInterface::REQUIRES_SUBSCRIPTION_YES,
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
     }
 
     public function testWithUploaderClonesObjectAndSetsValue()
@@ -800,7 +840,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providerInvalidLive
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
      * @param mixed $live
      */
@@ -821,31 +861,33 @@ class VideoTest extends \PHPUnit_Framework_TestCase
         $video->withLive($live);
     }
 
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidLive()
+    public function testWithLiveRejectsUnknownValue()
     {
-        $values = [
-            'foobarbaz',
-            true,
-        ];
+        $this->setExpectedException(InvalidArgumentException::class);
 
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
-    }
-
-    public function testWithLiveClonesObjectAndSetsValue()
-    {
         $faker = $this->getFaker();
 
-        $live = $faker->randomElement([
-            VideoInterface::LIVE_NO,
-            VideoInterface::LIVE_YES,
-        ]);
+        $live = $faker->sentence();
+
+        $video = new Video(
+            $faker->url,
+            $faker->sentence,
+            $faker->paragraphs(5, true),
+            $faker->url,
+            $this->getPlayerLocationMock()
+        );
+
+        $video->withLive($live);
+    }
+
+    /**
+     * @dataProvider providerLive
+     *
+     * @param string $live
+     */
+    public function testWithLiveClonesObjectAndSetsValue($live)
+    {
+        $faker = $this->getFaker();
 
         $video = new Video(
             $faker->url,
@@ -865,11 +907,11 @@ class VideoTest extends \PHPUnit_Framework_TestCase
     /**
      * @return \Generator
      */
-    public function providerInvalidLiveIsRejected()
+    public function providerLive()
     {
         $values = [
-            'foobarbaz',
-            true,
+            VideoInterface::LIVE_NO,
+            VideoInterface::LIVE_YES,
         ];
 
         foreach ($values as $value) {


### PR DESCRIPTION
This PR

* [x] increases verbosity of tests by making use of data providers shipped with `refinery29/test-util` and asserting that all accepted values can actually be set
