### PR TITLE
Fix: Too many arguments in constructor

### DIFF
--- a/test/Unit/Component/Video/PriceTest.php
+++ b/test/Unit/Component/Video/PriceTest.php
@@ -120,10 +120,6 @@ class PriceTest extends \PHPUnit_Framework_TestCase
 
         $price = new Price(
             $faker->randomFloat(2, PriceInterface::VALUE_MIN),
-            $faker->randomFloat(
-                2,
-                PriceInterface::VALUE_MIN
-            ),
             $faker->currencyCode
         );
 


### PR DESCRIPTION
This PR

* [x] fixes a test using too many arguments for a constructor

Follows #116.

🙍 This was the result of resolving a merge conflict.
