### PR TITLE
Fix: Avoid magic numbers

### DIFF
--- a/test/Unit/Writer/UrlWriterTest.php
+++ b/test/Unit/Writer/UrlWriterTest.php
@@ -64,8 +64,8 @@ class UrlWriterTest extends AbstractTestCase
         ]);
         $priority = $faker->randomFloat(
             2,
-            0,
-            1
+            UrlInterface::PRIORITY_MIN,
+            UrlInterface::PRIORITY_MAX
         );
         $images = [
             $this->getImageMock(),

--- a/test/Unit/Writer/Video/VideoWriterTest.php
+++ b/test/Unit/Writer/Video/VideoWriterTest.php
@@ -99,8 +99,8 @@ class VideoWriterTest extends AbstractTestCase
         $expirationDate = $faker->dateTime;
         $rating = $faker->randomFloat(
             1,
-            0,
-            5
+            VideoInterface::RATING_MIN,
+            VideoInterface::RATING_MAX
         );
         $viewCount = $faker->randomNumber();
         $familyFriendly = VideoInterface::FAMILY_FRIENDLY_NO;


### PR DESCRIPTION
This PR

* [x] avoids magic numbers in tests by using the existing constants in tests
