### PR TITLE
Fix: Use getMock()

### DIFF
--- a/test/Unit/Component/News/NewsTest.php
+++ b/test/Unit/Component/News/NewsTest.php
@@ -449,6 +449,6 @@ class NewsTest extends \PHPUnit_Framework_TestCase
      */
     private function getPublicationMock()
     {
-        return $this->getMockBuilder(PublicationInterface::class)->getMock();
+        return $this->getMock(PublicationInterface::class);
     }
 }

--- a/test/Unit/Component/SitemapIndexTest.php
+++ b/test/Unit/Component/SitemapIndexTest.php
@@ -85,6 +85,6 @@ class SitemapIndexTest extends \PHPUnit_Framework_TestCase
      */
     private function getSitemapMock()
     {
-        return $this->getMockBuilder(SitemapInterface::class)->getMock();
+        return $this->getMock(SitemapInterface::class);
     }
 }

--- a/test/Unit/Component/UrlSetTest.php
+++ b/test/Unit/Component/UrlSetTest.php
@@ -69,6 +69,6 @@ class UrlSetTest extends \PHPUnit_Framework_TestCase
      */
     private function getUrlMock()
     {
-        return $this->getMockBuilder(UrlInterface::class)->getMock();
+        return $this->getMock(UrlInterface::class);
     }
 }

--- a/test/Unit/Component/UrlTest.php
+++ b/test/Unit/Component/UrlTest.php
@@ -400,7 +400,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      */
     private function getImageMock()
     {
-        return $this->getMockBuilder(ImageInterface::class)->getMock();
+        return $this->getMock(ImageInterface::class);
     }
 
     /**
@@ -408,7 +408,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      */
     private function getNewsMock()
     {
-        return $this->getMockBuilder(NewsInterface::class)->getMock();
+        return $this->getMock(NewsInterface::class);
     }
 
     /**
@@ -416,6 +416,6 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      */
     private function getVideoMock()
     {
-        return $this->getMockBuilder(VideoInterface::class)->getMock();
+        return $this->getMock(VideoInterface::class);
     }
 }

--- a/test/Unit/Component/Video/VideoTest.php
+++ b/test/Unit/Component/Video/VideoTest.php
@@ -923,7 +923,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
      */
     private function getGalleryLocationMock()
     {
-        return $this->getMockBuilder(GalleryLocationInterface::class)->getMock();
+        return $this->getMock(GalleryLocationInterface::class);
     }
 
     /**
@@ -931,7 +931,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
      */
     private function getPlatformMock()
     {
-        return $this->getMockBuilder(PlatformInterface::class)->getMock();
+        return $this->getMock(PlatformInterface::class);
     }
 
     /**
@@ -939,7 +939,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
      */
     private function getPlayerLocationMock()
     {
-        return $this->getMockBuilder(PlayerLocationInterface::class)->getMock();
+        return $this->getMock(PlayerLocationInterface::class);
     }
 
     /**
@@ -947,7 +947,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
      */
     private function getPriceMock()
     {
-        return $this->getMockBuilder(PriceInterface::class)->getMock();
+        return $this->getMock(PriceInterface::class);
     }
 
     /**
@@ -955,7 +955,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
      */
     private function getRestrictionMock()
     {
-        return $this->getMockBuilder(RestrictionInterface::class)->getMock();
+        return $this->getMock(RestrictionInterface::class);
     }
 
     /**
@@ -963,7 +963,7 @@ class VideoTest extends \PHPUnit_Framework_TestCase
      */
     private function getTagMock()
     {
-        return $this->getMockBuilder(TagInterface::class)->getMock();
+        return $this->getMock(TagInterface::class);
     }
 
     /**
@@ -971,6 +971,6 @@ class VideoTest extends \PHPUnit_Framework_TestCase
      */
     private function getUploaderMock()
     {
-        return $this->getMockBuilder(UploaderInterface::class)->getMock();
+        return $this->getMock(UploaderInterface::class);
     }
 }

--- a/test/Unit/Writer/Image/ImageWriterTest.php
+++ b/test/Unit/Writer/Image/ImageWriterTest.php
@@ -82,7 +82,7 @@ class ImageWriterTest extends AbstractTestCase
      */
     private function getImageMock($location, $title = null, $caption = null, $geoLocation = null, $licence = null)
     {
-        $image = $this->getMockBuilder(ImageInterface::class)->getMock();
+        $image = $this->getMock(ImageInterface::class);
 
         $image
             ->expects($this->any())
@@ -122,6 +122,6 @@ class ImageWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/News/NewsWriterTest.php
+++ b/test/Unit/Writer/News/NewsWriterTest.php
@@ -135,7 +135,7 @@ class NewsWriterTest extends AbstractTestCase
         array $keywords = [],
         array $stockTickers = []
     ) {
-        $news = $this->getMockBuilder(NewsInterface::class)->getMock();
+        $news = $this->getMock(NewsInterface::class);
 
         $news
             ->expects($this->any())
@@ -187,7 +187,7 @@ class NewsWriterTest extends AbstractTestCase
      */
     private function getPublicationMock()
     {
-        return $this->getMockBuilder(PublicationInterface::class)->getMock();
+        return $this->getMock(PublicationInterface::class);
     }
 
     /**
@@ -195,7 +195,7 @@ class NewsWriterTest extends AbstractTestCase
      */
     private function getPublicationWriterMock()
     {
-        return $this->getMockBuilder(PublicationWriter::class)->getMock();
+        return $this->getMock(PublicationWriter::class);
     }
 
     /**
@@ -203,6 +203,6 @@ class NewsWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/News/PublicationWriterTest.php
+++ b/test/Unit/Writer/News/PublicationWriterTest.php
@@ -49,7 +49,7 @@ class PublicationWriterTest extends AbstractTestCase
      */
     private function getPublicationMock($name, $language)
     {
-        $publication = $this->getMockBuilder(PublicationInterface::class)->getMock();
+        $publication = $this->getMock(PublicationInterface::class);
 
         $publication
             ->expects($this->any())
@@ -71,6 +71,6 @@ class PublicationWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/SitemapIndexWriterTest.php
+++ b/test/Unit/Writer/SitemapIndexWriterTest.php
@@ -76,7 +76,7 @@ class SitemapIndexWriterTest extends AbstractTestCase
      */
     private function getSitemapIndexMock(array $sitemaps = [])
     {
-        $sitemapIndex = $this->getMockBuilder(SitemapIndexInterface::class)->getMock();
+        $sitemapIndex = $this->getMock(SitemapIndexInterface::class);
 
         $sitemapIndex
             ->expects($this->any())
@@ -92,7 +92,7 @@ class SitemapIndexWriterTest extends AbstractTestCase
      */
     private function getSitemapMock()
     {
-        return $this->getMockBuilder(SitemapInterface::class)->getMock();
+        return $this->getMock(SitemapInterface::class);
     }
 
     /**
@@ -100,7 +100,7 @@ class SitemapIndexWriterTest extends AbstractTestCase
      */
     private function getSitemapWriterMock()
     {
-        return $this->getMockBuilder(SitemapWriter::class)->getMock();
+        return $this->getMock(SitemapWriter::class);
     }
 
     /**
@@ -108,6 +108,6 @@ class SitemapIndexWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/SitemapWriterTest.php
+++ b/test/Unit/Writer/SitemapWriterTest.php
@@ -69,7 +69,7 @@ class SitemapWriterTest extends AbstractTestCase
      */
     private function getSitemapMock($location, \DateTime $lastModified = null)
     {
-        $sitemap = $this->getMockBuilder(SitemapInterface::class)->getMock();
+        $sitemap = $this->getMock(SitemapInterface::class);
 
         $sitemap
             ->expects($this->any())
@@ -91,6 +91,6 @@ class SitemapWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/UrlSetWriterTest.php
+++ b/test/Unit/Writer/UrlSetWriterTest.php
@@ -76,7 +76,7 @@ class UrlSetWriterTest extends AbstractTestCase
      */
     private function getUrlMock()
     {
-        return $this->getMockBuilder(UrlInterface::class)->getMock();
+        return $this->getMock(UrlInterface::class);
     }
 
     /**
@@ -86,7 +86,7 @@ class UrlSetWriterTest extends AbstractTestCase
      */
     private function getUrlSetMock(array $urls = [])
     {
-        $urlSet = $this->getMockBuilder(UrlSetInterface::class)->getMock();
+        $urlSet = $this->getMock(UrlSetInterface::class);
 
         $urlSet
             ->expects($this->any())
@@ -113,6 +113,6 @@ class UrlSetWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/UrlWriterTest.php
+++ b/test/Unit/Writer/UrlWriterTest.php
@@ -134,7 +134,7 @@ class UrlWriterTest extends AbstractTestCase
         array $news = [],
         array $videos = []
     ) {
-        $url = $this->getMockBuilder(UrlInterface::class)->getMock();
+        $url = $this->getMock(UrlInterface::class);
 
         $url
             ->expects($this->any())
@@ -186,7 +186,7 @@ class UrlWriterTest extends AbstractTestCase
      */
     private function getImageMock()
     {
-        return $this->getMockBuilder(ImageInterface::class)->getMock();
+        return $this->getMock(ImageInterface::class);
     }
 
     /**
@@ -194,7 +194,7 @@ class UrlWriterTest extends AbstractTestCase
      */
     private function getImageWriterMock()
     {
-        return $this->getMockBuilder(ImageWriter::class)->getMock();
+        return $this->getMock(ImageWriter::class);
     }
 
     /**
@@ -226,7 +226,7 @@ class UrlWriterTest extends AbstractTestCase
      */
     private function getNewsMock()
     {
-        return $this->getMockBuilder(NewsInterface::class)->getMock();
+        return $this->getMock(NewsInterface::class);
     }
 
     /**
@@ -269,7 +269,7 @@ class UrlWriterTest extends AbstractTestCase
      */
     private function getVideoMock()
     {
-        return $this->getMockBuilder(VideoInterface::class)->getMock();
+        return $this->getMock(VideoInterface::class);
     }
 
     /**
@@ -312,6 +312,6 @@ class UrlWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/GalleryLocationWriterTest.php
+++ b/test/Unit/Writer/Video/GalleryLocationWriterTest.php
@@ -63,7 +63,7 @@ class GalleryLocationWriterTest extends AbstractTestCase
      */
     private function getGalleryLocationMock($location, $title = null)
     {
-        $galleryLocation = $this->getMockBuilder(GalleryLocationInterface::class)->getMock();
+        $galleryLocation = $this->getMock(GalleryLocationInterface::class);
 
         $galleryLocation
             ->expects($this->any())
@@ -85,6 +85,6 @@ class GalleryLocationWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/PlatformWriterTest.php
+++ b/test/Unit/Writer/Video/PlatformWriterTest.php
@@ -54,7 +54,7 @@ class PlatformWriterTest extends AbstractTestCase
      */
     private function getPlatformMock($relationship, array $types)
     {
-        $platform = $this->getMockBuilder(PlatformInterface::class)->getMock();
+        $platform = $this->getMock(PlatformInterface::class);
 
         $platform
             ->expects($this->any())
@@ -76,6 +76,6 @@ class PlatformWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/PlayerLocationWriterTest.php
+++ b/test/Unit/Writer/Video/PlayerLocationWriterTest.php
@@ -70,7 +70,7 @@ class PlayerLocationWriterTest extends AbstractTestCase
      */
     private function getPlayerLocationMock($location, $allowEmbed = null, $autoPlay = null)
     {
-        $playerLocation = $this->getMockBuilder(PlayerLocationInterface::class)->getMock();
+        $playerLocation = $this->getMock(PlayerLocationInterface::class);
 
         $playerLocation
             ->expects($this->any())
@@ -98,6 +98,6 @@ class PlayerLocationWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/PriceWriterTest.php
+++ b/test/Unit/Writer/Video/PriceWriterTest.php
@@ -89,7 +89,7 @@ class PriceWriterTest extends AbstractTestCase
      */
     private function getPriceMock($currency, $value, $type = null, $resolution = null)
     {
-        $price = $this->getMockBuilder(PriceInterface::class)->getMock();
+        $price = $this->getMock(PriceInterface::class);
 
         $price
             ->expects($this->any())
@@ -123,6 +123,6 @@ class PriceWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/RestrictionWriterTest.php
+++ b/test/Unit/Writer/Video/RestrictionWriterTest.php
@@ -54,7 +54,7 @@ class RestrictionWriterTest extends AbstractTestCase
      */
     private function getRestrictionMock($relationship, array $countryCodes)
     {
-        $restriction = $this->getMockBuilder(RestrictionInterface::class)->getMock();
+        $restriction = $this->getMock(RestrictionInterface::class);
 
         $restriction
             ->expects($this->any())
@@ -76,6 +76,6 @@ class RestrictionWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/TagWriterTest.php
+++ b/test/Unit/Writer/Video/TagWriterTest.php
@@ -37,7 +37,7 @@ class TagWriterTest extends AbstractTestCase
      */
     private function getTagMock($content)
     {
-        $tag = $this->getMockBuilder(TagInterface::class)->getMock();
+        $tag = $this->getMock(TagInterface::class);
 
         $tag
             ->expects($this->any())
@@ -53,6 +53,6 @@ class TagWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/UploaderWriterTest.php
+++ b/test/Unit/Writer/Video/UploaderWriterTest.php
@@ -61,7 +61,7 @@ class UploaderWriterTest extends AbstractTestCase
      */
     private function getUploaderMock($name, $info = null)
     {
-        $uploader = $this->getMockBuilder(UploaderInterface::class)->getMock();
+        $uploader = $this->getMock(UploaderInterface::class);
 
         $uploader
             ->expects($this->any())
@@ -83,6 +83,6 @@ class UploaderWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/VideoWriterTest.php
+++ b/test/Unit/Writer/Video/VideoWriterTest.php
@@ -237,7 +237,7 @@ class VideoWriterTest extends AbstractTestCase
         array $prices = [],
         array $tags = []
     ) {
-        $video = $this->getMockBuilder(VideoInterface::class)->getMock();
+        $video = $this->getMock(VideoInterface::class);
 
         $video
             ->expects($this->any())
@@ -367,7 +367,7 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getGalleryLocationMock()
     {
-        return $this->getMockBuilder(GalleryLocationInterface::class)->getMock();
+        return $this->getMock(GalleryLocationInterface::class);
     }
 
     /**
@@ -375,7 +375,7 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getGalleryLocationWriterMock()
     {
-        return $this->getMockBuilder(GalleryLocationWriter::class)->getMock();
+        return $this->getMock(GalleryLocationWriter::class);
     }
 
     /**
@@ -405,7 +405,7 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getPlatformMock()
     {
-        return $this->getMockBuilder(PlatformInterface::class)->getMock();
+        return $this->getMock(PlatformInterface::class);
     }
 
     /**
@@ -413,7 +413,7 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getPlatformWriterMock()
     {
-        return $this->getMockBuilder(PlatformWriter::class)->getMock();
+        return $this->getMock(PlatformWriter::class);
     }
 
     /**
@@ -443,7 +443,7 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getPlayerLocationMock()
     {
-        return $this->getMockBuilder(PlayerLocationInterface::class)->getMock();
+        return $this->getMock(PlayerLocationInterface::class);
     }
 
     /**
@@ -451,7 +451,7 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getPlayerLocationWriterMock()
     {
-        return $this->getMockBuilder(PlayerLocationWriter::class)->getMock();
+        return $this->getMock(PlayerLocationWriter::class);
     }
 
     /**
@@ -481,7 +481,7 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getPriceMock()
     {
-        return $this->getMockBuilder(PriceInterface::class)->getMock();
+        return $this->getMock(PriceInterface::class);
     }
 
     /**
@@ -489,7 +489,7 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getPriceWriterMock()
     {
-        return $this->getMockBuilder(PriceWriter::class)->getMock();
+        return $this->getMock(PriceWriter::class);
     }
 
     /**
@@ -521,7 +521,7 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getRestrictionMock()
     {
-        return $this->getMockBuilder(RestrictionInterface::class)->getMock();
+        return $this->getMock(RestrictionInterface::class);
     }
 
     /**
@@ -529,7 +529,7 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getRestrictionWriterMock()
     {
-        return $restrictionWriter = $this->getMockBuilder(RestrictionWriter::class)->getMock();
+        return $restrictionWriter = $this->getMock(RestrictionWriter::class);
     }
 
     /**
@@ -559,7 +559,7 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getTagMock()
     {
-        return $this->getMockBuilder(TagInterface::class)->getMock();
+        return $this->getMock(TagInterface::class);
     }
 
     /**
@@ -567,7 +567,7 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getTagWriterMock()
     {
-        return $this->getMockBuilder(TagWriter::class)->getMock();
+        return $this->getMock(TagWriter::class);
     }
 
     /**
@@ -599,7 +599,7 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getUploaderMock()
     {
-        return $this->getMockBuilder(UploaderInterface::class)->getMock();
+        return $this->getMock(UploaderInterface::class);
     }
 
     /**
@@ -629,7 +629,7 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getUploaderWriterMock()
     {
-        return $this->getMockBuilder(UploaderWriter::class)->getMock();
+        return $this->getMock(UploaderWriter::class);
     }
 
     /**
@@ -637,6 +637,6 @@ class VideoWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMockBuilder(\XMLWriter::class)->getMock();
+        return $this->getMock(\XMLWriter::class);
     }
 }


### PR DESCRIPTION
This PR

* [x] uses `getMock()` instead of `getMockBuilder()->getMock()` where possible
