### PR TITLE
Bugfix: Change the doc block to reflect the function

### DIFF
--- a/src/Component/Url.php
+++ b/src/Component/Url.php
@@ -141,7 +141,7 @@ final class Url implements UrlInterface
     }
 
     /**
-     * @param string $priority
+     * @param float $priority
      *
      * @throws \InvalidArgumentException
      *


### PR DESCRIPTION
This PR

* [x] Doc block says string, function asserts float. Updated the doc block to reflect what the function actually does. 