### PR TITLE
Fix: Update refinery29/php-cs-fixer-config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "codeclimate/php-test-reporter": "0.3.2",
         "phpunit/phpunit": "^4.8.26",
-        "refinery29/php-cs-fixer-config": "0.4.16",
+        "refinery29/php-cs-fixer-config": "0.4.18",
         "refinery29/test-util": "0.4.3"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3cc2d7c75ef877625a5bc408c85f65a7",
-    "content-hash": "981164db6ab16322da5f8a27b4b03bfd",
+    "hash": "b85b5d2dbb2ed5b6d3e4511018370801",
+    "content-hash": "2c5369c07eb65f39796299270e89231f",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -896,16 +896,16 @@
         },
         {
             "name": "refinery29/php-cs-fixer-config",
-            "version": "0.4.16",
+            "version": "0.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/refinery29/php-cs-fixer-config.git",
-                "reference": "7dd3a4117f69300ba1c7ef69e9738f1bc1fdb312"
+                "reference": "661f282db4f10f8b047c68e2309228d9c1b2241b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/7dd3a4117f69300ba1c7ef69e9738f1bc1fdb312",
-                "reference": "7dd3a4117f69300ba1c7ef69e9738f1bc1fdb312",
+                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/661f282db4f10f8b047c68e2309228d9c1b2241b",
+                "reference": "661f282db4f10f8b047c68e2309228d9c1b2241b",
                 "shasum": ""
             },
             "require": {
@@ -913,8 +913,8 @@
                 "php": "^5.5 || ^7.0"
             },
             "require-dev": {
-                "codeclimate/php-test-reporter": "0.3.0",
-                "phpunit/phpunit": "^4.8.24"
+                "codeclimate/php-test-reporter": "0.3.2",
+                "phpunit/phpunit": "^4.8.26"
             },
             "type": "library",
             "autoload": {
@@ -933,7 +933,7 @@
                 }
             ],
             "description": "Provides a configuration for friendsofphp/php-cs-fixer, used within Refinery29.",
-            "time": "2016-05-31 13:24:02"
+            "time": "2016-07-14 09:57:54"
         },
         {
             "name": "refinery29/test-util",

--- a/test/Integration/Writer/UrlSetWriterTest.php
+++ b/test/Integration/Writer/UrlSetWriterTest.php
@@ -46,8 +46,7 @@ XML;
             ->withTitle('Herbert')
             ->withCaption('Big dog plays his cards')
             ->withGeoLocation('At the table')
-            ->withLicence('Public Domain')
-        ;
+            ->withLicence('Public Domain');
 
         $news = new Component\News\News(
             new Component\News\Publication(
@@ -72,8 +71,7 @@ XML;
             ->withStockTickers([
                 'GM',
                 'AAPL',
-            ])
-        ;
+            ]);
 
         $video = new Component\Video\Video(
             'http://www.example.com/thumbs/123.jpg',
@@ -85,8 +83,7 @@ XML;
         $playerLocation = new Component\Video\PlayerLocation('http://www.example.com/videoplayer.swf?video=234');
         $playerLocation = $playerLocation
             ->withAllowEmbed(Component\Video\PlayerLocationInterface::ALLOW_EMBED_YES)
-            ->withAutoPlay('ap=1')
-        ;
+            ->withAutoPlay('ap=1');
 
         $anotherVideo = new Component\Video\Video(
             'http://www.example.com/thumbs/234.jpg',
@@ -132,8 +129,7 @@ XML;
             ->withRequiresSubscription(Component\Video\VideoInterface::REQUIRES_SUBSCRIPTION_NO)
             ->withUploader(new Component\Video\Uploader('Jane Doe'))
             ->withPlatform($platform)
-            ->withLive(Component\Video\VideoInterface::LIVE_NO)
-        ;
+            ->withLive(Component\Video\VideoInterface::LIVE_NO);
 
         $url = $url
             ->withPriority(0.8)
@@ -147,8 +143,7 @@ XML;
             ->withVideos([
                 $video,
                 $anotherVideo,
-            ])
-        ;
+            ]);
 
         $urlSet = new Component\UrlSet([
            $url,

--- a/test/Unit/Writer/AbstractTestCase.php
+++ b/test/Unit/Writer/AbstractTestCase.php
@@ -29,8 +29,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
             ->with(
                 $this->identicalTo($version),
                 $this->identicalTo($charset)
-            )
-        ;
+            );
     }
 
     /**
@@ -42,8 +41,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
         $xmlWriter
             ->expects($this->next($xmlWriter))
             ->method('startElement')
-            ->with($this->identicalTo($name))
-        ;
+            ->with($this->identicalTo($name));
     }
 
     /**
@@ -59,24 +57,21 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
             ->with(
                 $this->identicalTo($name),
                 $this->identicalTo($value)
-            )
-        ;
+            );
     }
 
     protected function expectToEndElement(\PHPUnit_Framework_MockObject_MockObject $xmlWriter)
     {
         $xmlWriter
             ->expects($this->next($xmlWriter))
-            ->method('endElement')
-        ;
+            ->method('endElement');
     }
 
     protected function expectToEndDocument(\PHPUnit_Framework_MockObject_MockObject $xmlWriter)
     {
         $xmlWriter
             ->expects($this->next($xmlWriter))
-            ->method('endDocument')
-        ;
+            ->method('endDocument');
     }
 
     /**
@@ -97,8 +92,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
             $xmlWriter
                 ->expects($this->next($xmlWriter))
                 ->method('text')
-                ->with($this->identicalTo($text))
-            ;
+                ->with($this->identicalTo($text));
         }
 
         $this->expectToEndElement($xmlWriter);
@@ -111,8 +105,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
     {
         $xmlWriter
             ->expects($this->next($xmlWriter))
-            ->method('openMemory')
-        ;
+            ->method('openMemory');
     }
 
     /**
@@ -124,8 +117,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
         $xmlWriter
             ->expects($this->next($xmlWriter))
             ->method('outputMemory')
-            ->willReturn($output)
-        ;
+            ->willReturn($output);
     }
 
     /**

--- a/test/Unit/Writer/Image/ImageWriterTest.php
+++ b/test/Unit/Writer/Image/ImageWriterTest.php
@@ -87,32 +87,27 @@ class ImageWriterTest extends AbstractTestCase
         $image
             ->expects($this->any())
             ->method('location')
-            ->willReturn($location)
-        ;
+            ->willReturn($location);
 
         $image
             ->expects($this->any())
             ->method('title')
-            ->willReturn($title)
-        ;
+            ->willReturn($title);
 
         $image
             ->expects($this->any())
             ->method('caption')
-            ->willReturn($caption)
-        ;
+            ->willReturn($caption);
 
         $image
             ->expects($this->any())
             ->method('geoLocation')
-            ->willReturn($geoLocation)
-        ;
+            ->willReturn($geoLocation);
 
         $image
             ->expects($this->any())
             ->method('licence')
-            ->willReturn($licence)
-        ;
+            ->willReturn($licence);
 
         return $image;
     }

--- a/test/Unit/Writer/News/NewsWriterTest.php
+++ b/test/Unit/Writer/News/NewsWriterTest.php
@@ -54,8 +54,7 @@ class NewsWriterTest extends AbstractTestCase
             ->with(
                 $this->identicalTo($publication),
                 $this->identicalTo($xmlWriter)
-            )
-        ;
+            );
 
         $writer = new NewsWriter($publicationWriter);
 
@@ -107,8 +106,7 @@ class NewsWriterTest extends AbstractTestCase
             ->with(
                 $this->identicalTo($publication),
                 $this->identicalTo($xmlWriter)
-            )
-        ;
+            );
 
         $writer = new NewsWriter($publicationWriter);
 
@@ -140,44 +138,37 @@ class NewsWriterTest extends AbstractTestCase
         $news
             ->expects($this->any())
             ->method('publication')
-            ->willReturn($publication)
-        ;
+            ->willReturn($publication);
 
         $news
             ->expects($this->any())
             ->method('publicationDate')
-            ->willReturn($publicationDate)
-        ;
+            ->willReturn($publicationDate);
 
         $news
             ->expects($this->any())
             ->method('title')
-            ->willReturn($title)
-        ;
+            ->willReturn($title);
 
         $news
             ->expects($this->any())
             ->method('access')
-            ->willReturn($access)
-        ;
+            ->willReturn($access);
 
         $news
             ->expects($this->any())
             ->method('genres')
-            ->willReturn($genres)
-        ;
+            ->willReturn($genres);
 
         $news
             ->expects($this->any())
             ->method('keywords')
-            ->willReturn($keywords)
-        ;
+            ->willReturn($keywords);
 
         $news
             ->expects($this->any())
             ->method('stockTickers')
-            ->willReturn($stockTickers)
-        ;
+            ->willReturn($stockTickers);
 
         return $news;
     }

--- a/test/Unit/Writer/News/PublicationWriterTest.php
+++ b/test/Unit/Writer/News/PublicationWriterTest.php
@@ -54,14 +54,12 @@ class PublicationWriterTest extends AbstractTestCase
         $publication
             ->expects($this->any())
             ->method('name')
-            ->willReturn($name)
-        ;
+            ->willReturn($name);
 
         $publication
             ->expects($this->any())
             ->method('language')
-            ->willReturn($language)
-        ;
+            ->willReturn($language);
 
         return $publication;
     }

--- a/test/Unit/Writer/SitemapIndexWriterTest.php
+++ b/test/Unit/Writer/SitemapIndexWriterTest.php
@@ -56,8 +56,7 @@ class SitemapIndexWriterTest extends AbstractTestCase
                 ->with(
                     $this->identicalTo($sitemap),
                     $this->identicalTo($xmlWriter)
-                )
-            ;
+                );
         }
 
         $this->expectToEndDocument($xmlWriter);
@@ -81,8 +80,7 @@ class SitemapIndexWriterTest extends AbstractTestCase
         $sitemapIndex
             ->expects($this->any())
             ->method('sitemaps')
-            ->willReturn($sitemaps)
-        ;
+            ->willReturn($sitemaps);
 
         return $sitemapIndex;
     }

--- a/test/Unit/Writer/SitemapWriterTest.php
+++ b/test/Unit/Writer/SitemapWriterTest.php
@@ -74,14 +74,12 @@ class SitemapWriterTest extends AbstractTestCase
         $sitemap
             ->expects($this->any())
             ->method('location')
-            ->willReturn($location)
-        ;
+            ->willReturn($location);
 
         $sitemap
             ->expects($this->any())
             ->method('lastModified')
-            ->willReturn($lastModified)
-        ;
+            ->willReturn($lastModified);
 
         return $sitemap;
     }

--- a/test/Unit/Writer/UrlSetWriterTest.php
+++ b/test/Unit/Writer/UrlSetWriterTest.php
@@ -58,8 +58,7 @@ class UrlSetWriterTest extends AbstractTestCase
                 ->with(
                     $this->identicalTo($url),
                     $this->identicalTo($xmlWriter)
-                )
-            ;
+                );
         }
 
         $this->expectToEndElement($xmlWriter);
@@ -91,8 +90,7 @@ class UrlSetWriterTest extends AbstractTestCase
         $urlSet
             ->expects($this->any())
             ->method('urls')
-            ->willReturn($urls)
-        ;
+            ->willReturn($urls);
 
         return $urlSet;
     }
@@ -104,8 +102,7 @@ class UrlSetWriterTest extends AbstractTestCase
     {
         return $this->getMockBuilder(UrlWriter::class)
             ->disableOriginalConstructor()
-            ->getMock()
-        ;
+            ->getMock();
     }
 
     /**

--- a/test/Unit/Writer/UrlWriterTest.php
+++ b/test/Unit/Writer/UrlWriterTest.php
@@ -139,44 +139,37 @@ class UrlWriterTest extends AbstractTestCase
         $url
             ->expects($this->any())
             ->method('location')
-            ->willReturn($location)
-        ;
+            ->willReturn($location);
 
         $url
             ->expects($this->any())
             ->method('lastModified')
-            ->willReturn($lastModified)
-        ;
+            ->willReturn($lastModified);
 
         $url
             ->expects($this->any())
             ->method('changeFrequency')
-            ->willReturn($changeFrequency)
-        ;
+            ->willReturn($changeFrequency);
 
         $url
             ->expects($this->any())
             ->method('priority')
-            ->willReturn($priority)
-        ;
+            ->willReturn($priority);
 
         $url
             ->expects($this->any())
             ->method('images')
-            ->willReturn($images)
-        ;
+            ->willReturn($images);
 
         $url
             ->expects($this->any())
             ->method('news')
-            ->willReturn($news)
-        ;
+            ->willReturn($news);
 
         $url
             ->expects($this->any())
             ->method('videos')
-            ->willReturn($videos)
-        ;
+            ->willReturn($videos);
 
         return $url;
     }
@@ -214,8 +207,7 @@ class UrlWriterTest extends AbstractTestCase
                 ->with(
                     $this->identicalTo($image),
                     $this->identicalTo($xmlWriter)
-                )
-            ;
+                );
         }
 
         return $imageWriter;
@@ -236,8 +228,7 @@ class UrlWriterTest extends AbstractTestCase
     {
         return $this->getMockBuilder(NewsWriter::class)
             ->disableOriginalConstructor()
-            ->getMock()
-        ;
+            ->getMock();
     }
 
     /**
@@ -257,8 +248,7 @@ class UrlWriterTest extends AbstractTestCase
                 ->with(
                     $this->identicalTo($pieceOfNews),
                     $this->identicalTo($xmlWriter)
-                )
-            ;
+                );
         }
 
         return $newsWriter;
@@ -279,8 +269,7 @@ class UrlWriterTest extends AbstractTestCase
     {
         return $this->getMockBuilder(VideoWriter::class)
             ->disableOriginalConstructor()
-            ->getMock()
-        ;
+            ->getMock();
     }
 
     /**
@@ -300,8 +289,7 @@ class UrlWriterTest extends AbstractTestCase
                 ->with(
                     $this->identicalTo($video),
                     $this->identicalTo($xmlWriter)
-                )
-            ;
+                );
         }
 
         return $videoWriter;

--- a/test/Unit/Writer/Video/GalleryLocationWriterTest.php
+++ b/test/Unit/Writer/Video/GalleryLocationWriterTest.php
@@ -68,14 +68,12 @@ class GalleryLocationWriterTest extends AbstractTestCase
         $galleryLocation
             ->expects($this->any())
             ->method('location')
-            ->willReturn($location)
-        ;
+            ->willReturn($location);
 
         $galleryLocation
             ->expects($this->any())
             ->method('title')
-            ->willReturn($title)
-        ;
+            ->willReturn($title);
 
         return $galleryLocation;
     }

--- a/test/Unit/Writer/Video/PlatformWriterTest.php
+++ b/test/Unit/Writer/Video/PlatformWriterTest.php
@@ -59,14 +59,12 @@ class PlatformWriterTest extends AbstractTestCase
         $platform
             ->expects($this->any())
             ->method('relationship')
-            ->willReturn($relationship)
-        ;
+            ->willReturn($relationship);
 
         $platform
             ->expects($this->any())
             ->method('types')
-            ->willReturn($types)
-        ;
+            ->willReturn($types);
 
         return $platform;
     }

--- a/test/Unit/Writer/Video/PlayerLocationWriterTest.php
+++ b/test/Unit/Writer/Video/PlayerLocationWriterTest.php
@@ -75,20 +75,17 @@ class PlayerLocationWriterTest extends AbstractTestCase
         $playerLocation
             ->expects($this->any())
             ->method('location')
-            ->willReturn($location)
-        ;
+            ->willReturn($location);
 
         $playerLocation
             ->expects($this->any())
             ->method('allowEmbed')
-            ->willReturn($allowEmbed)
-        ;
+            ->willReturn($allowEmbed);
 
         $playerLocation
             ->expects($this->any())
             ->method('autoPlay')
-            ->willReturn($autoPlay)
-        ;
+            ->willReturn($autoPlay);
 
         return $playerLocation;
     }

--- a/test/Unit/Writer/Video/PriceWriterTest.php
+++ b/test/Unit/Writer/Video/PriceWriterTest.php
@@ -94,26 +94,22 @@ class PriceWriterTest extends AbstractTestCase
         $price
             ->expects($this->any())
             ->method('currency')
-            ->willReturn($currency)
-        ;
+            ->willReturn($currency);
 
         $price
             ->expects($this->any())
             ->method('value')
-            ->willReturn($value)
-        ;
+            ->willReturn($value);
 
         $price
             ->expects($this->any())
             ->method('type')
-            ->willReturn($type)
-        ;
+            ->willReturn($type);
 
         $price
             ->expects($this->any())
             ->method('resolution')
-            ->willReturn($resolution)
-        ;
+            ->willReturn($resolution);
 
         return $price;
     }

--- a/test/Unit/Writer/Video/RestrictionWriterTest.php
+++ b/test/Unit/Writer/Video/RestrictionWriterTest.php
@@ -59,14 +59,12 @@ class RestrictionWriterTest extends AbstractTestCase
         $restriction
             ->expects($this->any())
             ->method('relationship')
-            ->willReturn($relationship)
-        ;
+            ->willReturn($relationship);
 
         $restriction
             ->expects($this->any())
             ->method('countryCodes')
-            ->willReturn($countryCodes)
-        ;
+            ->willReturn($countryCodes);
 
         return $restriction;
     }

--- a/test/Unit/Writer/Video/TagWriterTest.php
+++ b/test/Unit/Writer/Video/TagWriterTest.php
@@ -42,8 +42,7 @@ class TagWriterTest extends AbstractTestCase
         $tag
             ->expects($this->any())
             ->method('content')
-            ->willReturn($content)
-        ;
+            ->willReturn($content);
 
         return $tag;
     }

--- a/test/Unit/Writer/Video/UploaderWriterTest.php
+++ b/test/Unit/Writer/Video/UploaderWriterTest.php
@@ -66,14 +66,12 @@ class UploaderWriterTest extends AbstractTestCase
         $uploader
             ->expects($this->any())
             ->method('name')
-            ->willReturn($name)
-        ;
+            ->willReturn($name);
 
         $uploader
             ->expects($this->any())
             ->method('info')
-            ->willReturn($info)
-        ;
+            ->willReturn($info);
 
         return $uploader;
     }

--- a/test/Unit/Writer/Video/VideoWriterTest.php
+++ b/test/Unit/Writer/Video/VideoWriterTest.php
@@ -242,122 +242,102 @@ class VideoWriterTest extends AbstractTestCase
         $video
             ->expects($this->any())
             ->method('thumbnailLocation')
-            ->willReturn($thumbnailLocation)
-        ;
+            ->willReturn($thumbnailLocation);
 
         $video
             ->expects($this->any())
             ->method('title')
-            ->willReturn($title)
-        ;
+            ->willReturn($title);
 
         $video
             ->expects($this->any())
             ->method('description')
-            ->willReturn($description)
-        ;
+            ->willReturn($description);
 
         $video
             ->expects($this->any())
             ->method('contentLocation')
-            ->willReturn($contentLocation)
-        ;
+            ->willReturn($contentLocation);
 
         $video
             ->expects($this->any())
             ->method('playerLocation')
-            ->willReturn($playerLocation)
-        ;
+            ->willReturn($playerLocation);
 
         $video
             ->expects($this->any())
             ->method('galleryLocation')
-            ->willReturn($galleryLocation)
-        ;
+            ->willReturn($galleryLocation);
 
         $video
             ->expects($this->any())
             ->method('duration')
-            ->willReturn($duration)
-        ;
+            ->willReturn($duration);
 
         $video
             ->expects($this->any())
             ->method('publicationDate')
-            ->willReturn($publicationDate)
-        ;
+            ->willReturn($publicationDate);
 
         $video
             ->expects($this->any())
             ->method('expirationDate')
-            ->willReturn($expirationDate)
-        ;
+            ->willReturn($expirationDate);
 
         $video
             ->expects($this->any())
             ->method('rating')
-            ->willReturn($rating)
-        ;
+            ->willReturn($rating);
 
         $video
             ->expects($this->any())
             ->method('viewCount')
-            ->willReturn($viewCount)
-        ;
+            ->willReturn($viewCount);
 
         $video
             ->expects($this->any())
             ->method('familyFriendly')
-            ->willReturn($familyFriendly)
-        ;
+            ->willReturn($familyFriendly);
 
         $video
             ->expects($this->any())
             ->method('category')
-            ->willReturn($category)
-        ;
+            ->willReturn($category);
 
         $video
             ->expects($this->any())
             ->method('restriction')
-            ->willReturn($restriction)
-        ;
+            ->willReturn($restriction);
 
         $video
             ->expects($this->any())
             ->method('requiresSubscription')
-            ->willReturn($requiresSubscription)
-        ;
+            ->willReturn($requiresSubscription);
 
         $video
             ->expects($this->any())
             ->method('uploader')
-            ->willReturn($uploader)
-        ;
+            ->willReturn($uploader);
 
         $video
             ->expects($this->any())
             ->method('platform')
-            ->willReturn($platform)
-        ;
+            ->willReturn($platform);
 
         $video
             ->expects($this->any())
             ->method('live')
-            ->willReturn($live)
-        ;
+            ->willReturn($live);
 
         $video
             ->expects($this->any())
             ->method('prices')
-            ->willReturn($prices)
-        ;
+            ->willReturn($prices);
 
         $video
             ->expects($this->any())
             ->method('tags')
-            ->willReturn($tags)
-        ;
+            ->willReturn($tags);
 
         return $video;
     }
@@ -394,8 +374,7 @@ class VideoWriterTest extends AbstractTestCase
             ->with(
                 $this->identicalTo($galleryLocation),
                 $this->identicalTo($xmlWriter)
-            )
-        ;
+            );
 
         return $galleryLocationWriter;
     }
@@ -432,8 +411,7 @@ class VideoWriterTest extends AbstractTestCase
             ->with(
                 $this->identicalTo($platform),
                 $this->identicalTo($xmlWriter)
-            )
-        ;
+            );
 
         return $platformWriter;
     }
@@ -470,8 +448,7 @@ class VideoWriterTest extends AbstractTestCase
             ->with(
                 $this->identicalTo($playerLocation),
                 $this->identicalTo($xmlWriter)
-            )
-        ;
+            );
 
         return $playerLocationWriter;
     }
@@ -509,8 +486,7 @@ class VideoWriterTest extends AbstractTestCase
                 ->with(
                     $this->identicalTo($price),
                     $this->identicalTo($xmlWriter)
-                )
-            ;
+                );
         }
 
         return $priceWriter;
@@ -548,8 +524,7 @@ class VideoWriterTest extends AbstractTestCase
             ->with(
                 $this->identicalTo($restriction),
                 $this->identicalTo($xmlWriter)
-            )
-        ;
+            );
 
         return $restrictionWriter;
     }
@@ -587,8 +562,7 @@ class VideoWriterTest extends AbstractTestCase
                 ->with(
                     $this->identicalTo($tag),
                     $this->identicalTo($xmlWriter)
-                )
-            ;
+                );
         }
 
         return $tagWriter;
@@ -618,8 +592,7 @@ class VideoWriterTest extends AbstractTestCase
             ->with(
                 $this->identicalTo($uploader),
                 $this->identicalTo($xmlWriter)
-            )
-        ;
+            );
 
         return $uploaderWriter;
     }


### PR DESCRIPTION
This PR

* [x] updates `refinery29/php-cs-fixer-config`
* [x] runs `make cs`

💁 For reference, see https://github.com/refinery29/php-cs-fixer-config/compare/0.4.16...0.4.18.