### PR TITLE
Enhancement: Update refinery29/test-util

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "codeclimate/php-test-reporter": "0.3.2",
         "phpunit/phpunit": "^4.8.27",
         "refinery29/php-cs-fixer-config": "0.5.0",
-        "refinery29/test-util": "0.4.3"
+        "refinery29/test-util": "0.9.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1894e47ba8eea83285f232d024e5be07",
-    "content-hash": "5a15c5c304ca847d0fcadb20d41f97d8",
+    "hash": "7959c5e3793ea995f964e47f0ae8d208",
+    "content-hash": "728fadd7428c1bbab915b055756d46a3",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1041,30 +1041,27 @@
         },
         {
             "name": "refinery29/test-util",
-            "version": "0.4.3",
+            "version": "0.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/refinery29/test-util.git",
-                "reference": "a81600f3d51c85982e6980a0e6824acbfc0263f0"
+                "reference": "0b17af63e14c339e9187daf722f44539d665794b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/refinery29/test-util/zipball/a81600f3d51c85982e6980a0e6824acbfc0263f0",
-                "reference": "a81600f3d51c85982e6980a0e6824acbfc0263f0",
+                "url": "https://api.github.com/repos/refinery29/test-util/zipball/0b17af63e14c339e9187daf722f44539d665794b",
+                "reference": "0b17af63e14c339e9187daf722f44539d665794b",
                 "shasum": ""
             },
             "require": {
                 "fzaninotto/faker": "^1.6.0",
-                "php": ">=5.5"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "beberlei/assert": "^2.5.0",
-                "codeclimate/php-test-reporter": "0.2.0",
-                "phpunit/phpunit": "^4.8.18 || ^5.2.3",
-                "refinery29/php-cs-fixer-config": "0.4.11"
-            },
-            "suggest": {
-                "phpunit/phpunit": "If you want to make use of the PHPUnit\\BuildsMocksTrait"
+                "beberlei/assert": "^2.6.5",
+                "codeclimate/php-test-reporter": "0.3.2",
+                "phpunit/phpunit": "^5.6.1",
+                "refinery29/php-cs-fixer-config": "0.4.20"
             },
             "type": "library",
             "autoload": {
@@ -1078,25 +1075,25 @@
             ],
             "authors": [
                 {
-                    "name": "Kayla Daniels",
-                    "email": "kayla.daniels@refinery29.com"
-                },
-                {
                     "name": "Andreas Möller",
                     "email": "andreas.moller@refinery29.com"
                 },
                 {
                     "name": "R29 Product & Engineering",
                     "email": "p.e@refinery29.com"
+                },
+                {
+                    "name": "Graham Daniels",
+                    "email": "graham.daniels@refinery29.com"
                 }
             ],
-            "description": "Provides helpers for testing.",
+            "description": "Provides a test helper, generic data providers, and assertions.",
             "keywords": [
                 "faker",
                 "test",
                 "util"
             ],
-            "time": "2016-05-15 20:56:52"
+            "time": "2016-10-31 17:52:01"
         },
         {
             "name": "satooshi/php-coveralls",

--- a/test/Unit/Component/Image/ImageTest.php
+++ b/test/Unit/Component/Image/ImageTest.php
@@ -11,11 +11,11 @@ namespace Refinery29\Sitemap\Test\Unit\Component\Image;
 
 use Refinery29\Sitemap\Component\Image\Image;
 use Refinery29\Sitemap\Component\Image\ImageInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class ImageTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Unit/Component/News/NewsInterfaceTest.php
+++ b/test/Unit/Component/News/NewsInterfaceTest.php
@@ -10,11 +10,11 @@
 namespace Refinery29\Sitemap\Test\Unit\Component\News;
 
 use Refinery29\Sitemap\Component\News\NewsInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class NewsInterfaceTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testConstants()
     {

--- a/test/Unit/Component/News/NewsTest.php
+++ b/test/Unit/Component/News/NewsTest.php
@@ -12,11 +12,11 @@ namespace Refinery29\Sitemap\Test\Unit\Component\News;
 use Refinery29\Sitemap\Component\News\News;
 use Refinery29\Sitemap\Component\News\NewsInterface;
 use Refinery29\Sitemap\Component\News\PublicationInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class NewsTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Unit/Component/News/PublicationTest.php
+++ b/test/Unit/Component/News/PublicationTest.php
@@ -11,11 +11,11 @@ namespace Refinery29\Sitemap\Test\Unit\Component\News;
 
 use Refinery29\Sitemap\Component\News\Publication;
 use Refinery29\Sitemap\Component\News\PublicationInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class PublicationTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Unit/Component/SitemapIndexTest.php
+++ b/test/Unit/Component/SitemapIndexTest.php
@@ -12,11 +12,11 @@ namespace Refinery29\Sitemap\Test\Unit\Component;
 use Refinery29\Sitemap\Component\SitemapIndex;
 use Refinery29\Sitemap\Component\SitemapIndexInterface;
 use Refinery29\Sitemap\Component\SitemapInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class SitemapIndexTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Unit/Component/SitemapTest.php
+++ b/test/Unit/Component/SitemapTest.php
@@ -11,11 +11,11 @@ namespace Refinery29\Sitemap\Test\Unit\Component;
 
 use Refinery29\Sitemap\Component\Sitemap;
 use Refinery29\Sitemap\Component\SitemapInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class SitemapTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Unit/Component/UrlSetInterfaceTest.php
+++ b/test/Unit/Component/UrlSetInterfaceTest.php
@@ -10,11 +10,11 @@
 namespace Refinery29\Sitemap\Test\Unit\Component;
 
 use Refinery29\Sitemap\Component\UrlSetInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class UrlSetInterfaceTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testConstants()
     {

--- a/test/Unit/Component/UrlSetTest.php
+++ b/test/Unit/Component/UrlSetTest.php
@@ -12,11 +12,11 @@ namespace Refinery29\Sitemap\Test\Unit\Component;
 use Refinery29\Sitemap\Component\UrlInterface;
 use Refinery29\Sitemap\Component\UrlSet;
 use Refinery29\Sitemap\Component\UrlSetInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class UrlSetTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Unit/Component/UrlTest.php
+++ b/test/Unit/Component/UrlTest.php
@@ -14,11 +14,11 @@ use Refinery29\Sitemap\Component\News\NewsInterface;
 use Refinery29\Sitemap\Component\Url;
 use Refinery29\Sitemap\Component\UrlInterface;
 use Refinery29\Sitemap\Component\Video\VideoInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class UrlTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Unit/Component/Video/GalleryLocationTest.php
+++ b/test/Unit/Component/Video/GalleryLocationTest.php
@@ -11,11 +11,11 @@ namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\GalleryLocation;
 use Refinery29\Sitemap\Component\Video\GalleryLocationInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class GalleryLocationTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Unit/Component/Video/PlatformTest.php
+++ b/test/Unit/Component/Video/PlatformTest.php
@@ -11,11 +11,11 @@ namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\Platform;
 use Refinery29\Sitemap\Component\Video\PlatformInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class PlatformTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Unit/Component/Video/PlayerLocationTest.php
+++ b/test/Unit/Component/Video/PlayerLocationTest.php
@@ -11,11 +11,11 @@ namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\PlayerLocation;
 use Refinery29\Sitemap\Component\Video\PlayerLocationInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class PlayerLocationTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testConstants()
     {

--- a/test/Unit/Component/Video/PriceTest.php
+++ b/test/Unit/Component/Video/PriceTest.php
@@ -11,11 +11,11 @@ namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\Price;
 use Refinery29\Sitemap\Component\Video\PriceInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class PriceTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Unit/Component/Video/RestrictionInterfaceTest.php
+++ b/test/Unit/Component/Video/RestrictionInterfaceTest.php
@@ -10,11 +10,11 @@
 namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\RestrictionInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class RestrictionInterfaceTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testConstants()
     {

--- a/test/Unit/Component/Video/RestrictionTest.php
+++ b/test/Unit/Component/Video/RestrictionTest.php
@@ -11,11 +11,11 @@ namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\Restriction;
 use Refinery29\Sitemap\Component\Video\RestrictionInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class RestrictionTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Unit/Component/Video/TagTest.php
+++ b/test/Unit/Component/Video/TagTest.php
@@ -11,11 +11,11 @@ namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\Tag;
 use Refinery29\Sitemap\Component\Video\TagInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class TagTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Unit/Component/Video/UploaderTest.php
+++ b/test/Unit/Component/Video/UploaderTest.php
@@ -11,11 +11,11 @@ namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\Uploader;
 use Refinery29\Sitemap\Component\Video\UploaderInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class UploaderTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Unit/Component/Video/VideoTest.php
+++ b/test/Unit/Component/Video/VideoTest.php
@@ -18,11 +18,11 @@ use Refinery29\Sitemap\Component\Video\TagInterface;
 use Refinery29\Sitemap\Component\Video\UploaderInterface;
 use Refinery29\Sitemap\Component\Video\Video;
 use Refinery29\Sitemap\Component\Video\VideoInterface;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class VideoTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Unit/Writer/AbstractTestCase.php
+++ b/test/Unit/Writer/AbstractTestCase.php
@@ -9,12 +9,12 @@
 
 namespace Refinery29\Sitemap\Test\Unit\Writer;
 
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 use SplObjectStorage;
 
 abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     /**
      * @param \PHPUnit_Framework_MockObject_MockObject $xmlWriter

--- a/test/Unit/Writer/SitemapIndexWriterTest.php
+++ b/test/Unit/Writer/SitemapIndexWriterTest.php
@@ -13,12 +13,9 @@ use Refinery29\Sitemap\Component\SitemapIndexInterface;
 use Refinery29\Sitemap\Component\SitemapInterface;
 use Refinery29\Sitemap\Writer\SitemapIndexWriter;
 use Refinery29\Sitemap\Writer\SitemapWriter;
-use Refinery29\Test\Util\TestHelper;
 
 class SitemapIndexWriterTest extends AbstractTestCase
 {
-    use TestHelper;
-
     public function testConstructorCreatesRequiredWriter()
     {
         $writer = new SitemapIndexWriter();

--- a/test/Unit/Writer/SitemapIndexWriterTest.php
+++ b/test/Unit/Writer/SitemapIndexWriterTest.php
@@ -13,11 +13,11 @@ use Refinery29\Sitemap\Component\SitemapIndexInterface;
 use Refinery29\Sitemap\Component\SitemapInterface;
 use Refinery29\Sitemap\Writer\SitemapIndexWriter;
 use Refinery29\Sitemap\Writer\SitemapWriter;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class SitemapIndexWriterTest extends AbstractTestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testConstructorCreatesRequiredWriter()
     {


### PR DESCRIPTION
This PR

* [x] updates `refinery29/test-util`
* [x] uses the `TestHelper` trait instead of the previously removed `GeneratorTrait`
* [x] imports the `TestHelper` trait once only

💁‍♂️ For reference, see https://github.com/refinery29/test-util/compare/0.4.3...0.9.5.