### PR TITLE
Fix: Mark tests as final

### DIFF
--- a/test/Integration/Writer/SitemapIndexWriterTest.php
+++ b/test/Integration/Writer/SitemapIndexWriterTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Sitemap;
 use Refinery29\Sitemap\Component\SitemapIndex;
 use Refinery29\Sitemap\Writer\SitemapIndexWriter;
 
-class SitemapIndexWriterTest extends \PHPUnit_Framework_TestCase
+final class SitemapIndexWriterTest extends \PHPUnit_Framework_TestCase
 {
     public function testWriteCreatesXml()
     {

--- a/test/Integration/Writer/UrlSetWriterTest.php
+++ b/test/Integration/Writer/UrlSetWriterTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Sitemap\Test\Integration\Writer;
 use Refinery29\Sitemap\Component;
 use Refinery29\Sitemap\Writer;
 
-class UrlSetWriterTest extends \PHPUnit_Framework_TestCase
+final class UrlSetWriterTest extends \PHPUnit_Framework_TestCase
 {
     public function testWriteSimpleSitemap()
     {

--- a/test/Unit/Component/Image/ImageInterfaceTest.php
+++ b/test/Unit/Component/Image/ImageInterfaceTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Sitemap\Test\Unit\Component\Image;
 
 use Refinery29\Sitemap\Component\Image\ImageInterface;
 
-class ImageInterfaceTest extends \PHPUnit_Framework_TestCase
+final class ImageInterfaceTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstants()
     {

--- a/test/Unit/Component/Image/ImageTest.php
+++ b/test/Unit/Component/Image/ImageTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Image\Image;
 use Refinery29\Sitemap\Component\Image\ImageInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class ImageTest extends \PHPUnit_Framework_TestCase
+final class ImageTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/News/NewsInterfaceTest.php
+++ b/test/Unit/Component/News/NewsInterfaceTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Sitemap\Test\Unit\Component\News;
 use Refinery29\Sitemap\Component\News\NewsInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class NewsInterfaceTest extends \PHPUnit_Framework_TestCase
+final class NewsInterfaceTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/News/NewsTest.php
+++ b/test/Unit/Component/News/NewsTest.php
@@ -14,7 +14,7 @@ use Refinery29\Sitemap\Component\News\NewsInterface;
 use Refinery29\Sitemap\Component\News\PublicationInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class NewsTest extends \PHPUnit_Framework_TestCase
+final class NewsTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/News/PublicationTest.php
+++ b/test/Unit/Component/News/PublicationTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\News\Publication;
 use Refinery29\Sitemap\Component\News\PublicationInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class PublicationTest extends \PHPUnit_Framework_TestCase
+final class PublicationTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/SitemapIndexTest.php
+++ b/test/Unit/Component/SitemapIndexTest.php
@@ -14,7 +14,7 @@ use Refinery29\Sitemap\Component\SitemapIndexInterface;
 use Refinery29\Sitemap\Component\SitemapInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class SitemapIndexTest extends \PHPUnit_Framework_TestCase
+final class SitemapIndexTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/SitemapTest.php
+++ b/test/Unit/Component/SitemapTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Sitemap;
 use Refinery29\Sitemap\Component\SitemapInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class SitemapTest extends \PHPUnit_Framework_TestCase
+final class SitemapTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/UrlInterfaceTest.php
+++ b/test/Unit/Component/UrlInterfaceTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Sitemap\Test\Unit\Component;
 
 use Refinery29\Sitemap\Component\UrlInterface;
 
-class UrlInterfaceTest extends \PHPUnit_Framework_TestCase
+final class UrlInterfaceTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstants()
     {

--- a/test/Unit/Component/UrlSetInterfaceTest.php
+++ b/test/Unit/Component/UrlSetInterfaceTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Sitemap\Test\Unit\Component;
 use Refinery29\Sitemap\Component\UrlSetInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class UrlSetInterfaceTest extends \PHPUnit_Framework_TestCase
+final class UrlSetInterfaceTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/UrlSetTest.php
+++ b/test/Unit/Component/UrlSetTest.php
@@ -14,7 +14,7 @@ use Refinery29\Sitemap\Component\UrlSet;
 use Refinery29\Sitemap\Component\UrlSetInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class UrlSetTest extends \PHPUnit_Framework_TestCase
+final class UrlSetTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/UrlTest.php
+++ b/test/Unit/Component/UrlTest.php
@@ -16,7 +16,7 @@ use Refinery29\Sitemap\Component\UrlInterface;
 use Refinery29\Sitemap\Component\Video\VideoInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class UrlTest extends \PHPUnit_Framework_TestCase
+final class UrlTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/Video/GalleryLocationTest.php
+++ b/test/Unit/Component/Video/GalleryLocationTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Video\GalleryLocation;
 use Refinery29\Sitemap\Component\Video\GalleryLocationInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class GalleryLocationTest extends \PHPUnit_Framework_TestCase
+final class GalleryLocationTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/Video/PlatformInterfaceTest.php
+++ b/test/Unit/Component/Video/PlatformInterfaceTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\PlatformInterface;
 
-class PlatformInterfaceTest extends \PHPUnit_Framework_TestCase
+final class PlatformInterfaceTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstants()
     {

--- a/test/Unit/Component/Video/PlatformTest.php
+++ b/test/Unit/Component/Video/PlatformTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Video\Platform;
 use Refinery29\Sitemap\Component\Video\PlatformInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class PlatformTest extends \PHPUnit_Framework_TestCase
+final class PlatformTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/Video/PlayerLocationInterfaceTest.php
+++ b/test/Unit/Component/Video/PlayerLocationInterfaceTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\PlayerLocationInterface;
 
-class PlayerLocationInterfaceTest extends \PHPUnit_Framework_TestCase
+final class PlayerLocationInterfaceTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstants()
     {

--- a/test/Unit/Component/Video/PlayerLocationTest.php
+++ b/test/Unit/Component/Video/PlayerLocationTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Video\PlayerLocation;
 use Refinery29\Sitemap\Component\Video\PlayerLocationInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class PlayerLocationTest extends \PHPUnit_Framework_TestCase
+final class PlayerLocationTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/Video/PriceInterfaceTest.php
+++ b/test/Unit/Component/Video/PriceInterfaceTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\PriceInterface;
 
-class PriceInterfaceTest extends \PHPUnit_Framework_TestCase
+final class PriceInterfaceTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstants()
     {

--- a/test/Unit/Component/Video/PriceTest.php
+++ b/test/Unit/Component/Video/PriceTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Video\Price;
 use Refinery29\Sitemap\Component\Video\PriceInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class PriceTest extends \PHPUnit_Framework_TestCase
+final class PriceTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/Video/RestrictionInterfaceTest.php
+++ b/test/Unit/Component/Video/RestrictionInterfaceTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 use Refinery29\Sitemap\Component\Video\RestrictionInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class RestrictionInterfaceTest extends \PHPUnit_Framework_TestCase
+final class RestrictionInterfaceTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/Video/RestrictionTest.php
+++ b/test/Unit/Component/Video/RestrictionTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Video\Restriction;
 use Refinery29\Sitemap\Component\Video\RestrictionInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class RestrictionTest extends \PHPUnit_Framework_TestCase
+final class RestrictionTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/Video/TagTest.php
+++ b/test/Unit/Component/Video/TagTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Video\Tag;
 use Refinery29\Sitemap\Component\Video\TagInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class TagTest extends \PHPUnit_Framework_TestCase
+final class TagTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/Video/UploaderTest.php
+++ b/test/Unit/Component/Video/UploaderTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Video\Uploader;
 use Refinery29\Sitemap\Component\Video\UploaderInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class UploaderTest extends \PHPUnit_Framework_TestCase
+final class UploaderTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Component/Video/VideoInterfaceTest.php
+++ b/test/Unit/Component/Video/VideoInterfaceTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Sitemap\Test\Unit\Component\Video;
 
 use Refinery29\Sitemap\Component\Video\VideoInterface;
 
-class VideoInterfaceTest extends \PHPUnit_Framework_TestCase
+final class VideoInterfaceTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstants()
     {

--- a/test/Unit/Component/Video/VideoTest.php
+++ b/test/Unit/Component/Video/VideoTest.php
@@ -20,7 +20,7 @@ use Refinery29\Sitemap\Component\Video\Video;
 use Refinery29\Sitemap\Component\Video\VideoInterface;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class VideoTest extends \PHPUnit_Framework_TestCase
+final class VideoTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Writer/AbstractTestCase.php
+++ b/test/Unit/Writer/AbstractTestCase.php
@@ -21,7 +21,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
      * @param string                                   $version
      * @param string                                   $charset
      */
-    protected function expectToStartDocument(\PHPUnit_Framework_MockObject_MockObject $xmlWriter, $version = '1.0', $charset = 'UTF-8')
+    final protected function expectToStartDocument(\PHPUnit_Framework_MockObject_MockObject $xmlWriter, $version = '1.0', $charset = 'UTF-8')
     {
         $xmlWriter
             ->expects($this->next($xmlWriter))
@@ -36,7 +36,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
      * @param \PHPUnit_Framework_MockObject_MockObject $xmlWriter
      * @param string                                   $name
      */
-    protected function expectToStartElement(\PHPUnit_Framework_MockObject_MockObject $xmlWriter, $name)
+    final protected function expectToStartElement(\PHPUnit_Framework_MockObject_MockObject $xmlWriter, $name)
     {
         $xmlWriter
             ->expects($this->next($xmlWriter))
@@ -49,7 +49,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
      * @param string                                   $name
      * @param mixed                                    $value
      */
-    protected function expectToWriteAttribute(\PHPUnit_Framework_MockObject_MockObject $xmlWriter, $name, $value)
+    final protected function expectToWriteAttribute(\PHPUnit_Framework_MockObject_MockObject $xmlWriter, $name, $value)
     {
         $xmlWriter
             ->expects($this->next($xmlWriter))
@@ -60,14 +60,14 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
             );
     }
 
-    protected function expectToEndElement(\PHPUnit_Framework_MockObject_MockObject $xmlWriter)
+    final protected function expectToEndElement(\PHPUnit_Framework_MockObject_MockObject $xmlWriter)
     {
         $xmlWriter
             ->expects($this->next($xmlWriter))
             ->method('endElement');
     }
 
-    protected function expectToEndDocument(\PHPUnit_Framework_MockObject_MockObject $xmlWriter)
+    final protected function expectToEndDocument(\PHPUnit_Framework_MockObject_MockObject $xmlWriter)
     {
         $xmlWriter
             ->expects($this->next($xmlWriter))
@@ -80,7 +80,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
      * @param mixed                                    $text
      * @param array                                    $attributes
      */
-    protected function expectToWriteElement(\PHPUnit_Framework_MockObject_MockObject $xmlWriter, $name, $text = null, array $attributes = [])
+    final protected function expectToWriteElement(\PHPUnit_Framework_MockObject_MockObject $xmlWriter, $name, $text = null, array $attributes = [])
     {
         $this->expectToStartElement($xmlWriter, $name);
 
@@ -101,7 +101,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
     /**
      * @param \PHPUnit_Framework_MockObject_MockObject $xmlWriter
      */
-    protected function expectToOpenMemory($xmlWriter)
+    final protected function expectToOpenMemory($xmlWriter)
     {
         $xmlWriter
             ->expects($this->next($xmlWriter))
@@ -112,7 +112,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
      * @param \PHPUnit_Framework_MockObject_MockObject $xmlWriter
      * @param string                                   $output
      */
-    protected function expectToOutput($xmlWriter, $output)
+    final protected function expectToOutput($xmlWriter, $output)
     {
         $xmlWriter
             ->expects($this->next($xmlWriter))
@@ -127,7 +127,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
      *
      * @return \PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex
      */
-    protected function next(\PHPUnit_Framework_MockObject_MockObject $mockObject)
+    final protected function next(\PHPUnit_Framework_MockObject_MockObject $mockObject)
     {
         static $invocations;
 

--- a/test/Unit/Writer/Image/ImageWriterTest.php
+++ b/test/Unit/Writer/Image/ImageWriterTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Image\ImageInterface;
 use Refinery29\Sitemap\Test\Unit\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\Image\ImageWriter;
 
-class ImageWriterTest extends AbstractTestCase
+final class ImageWriterTest extends AbstractTestCase
 {
     public function testWriteSimpleImage()
     {

--- a/test/Unit/Writer/News/NewsWriterTest.php
+++ b/test/Unit/Writer/News/NewsWriterTest.php
@@ -15,7 +15,7 @@ use Refinery29\Sitemap\Test\Unit\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\News\NewsWriter;
 use Refinery29\Sitemap\Writer\News\PublicationWriter;
 
-class NewsWriterTest extends AbstractTestCase
+final class NewsWriterTest extends AbstractTestCase
 {
     public function testConstructorCreatesRequiredWriter()
     {

--- a/test/Unit/Writer/News/PublicationWriterTest.php
+++ b/test/Unit/Writer/News/PublicationWriterTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\News\PublicationInterface;
 use Refinery29\Sitemap\Test\Unit\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\News\PublicationWriter;
 
-class PublicationWriterTest extends AbstractTestCase
+final class PublicationWriterTest extends AbstractTestCase
 {
     public function testWritePublication()
     {

--- a/test/Unit/Writer/SitemapIndexWriterTest.php
+++ b/test/Unit/Writer/SitemapIndexWriterTest.php
@@ -15,7 +15,7 @@ use Refinery29\Sitemap\Writer\SitemapIndexWriter;
 use Refinery29\Sitemap\Writer\SitemapWriter;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
-class SitemapIndexWriterTest extends AbstractTestCase
+final class SitemapIndexWriterTest extends AbstractTestCase
 {
     use GeneratorTrait;
 

--- a/test/Unit/Writer/SitemapWriterTest.php
+++ b/test/Unit/Writer/SitemapWriterTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Sitemap\Test\Unit\Writer;
 use Refinery29\Sitemap\Component\SitemapInterface;
 use Refinery29\Sitemap\Writer\SitemapWriter;
 
-class SitemapWriterTest extends AbstractTestCase
+final class SitemapWriterTest extends AbstractTestCase
 {
     public function testWriteSimpleSitemap()
     {

--- a/test/Unit/Writer/UrlSetWriterTest.php
+++ b/test/Unit/Writer/UrlSetWriterTest.php
@@ -17,7 +17,7 @@ use Refinery29\Sitemap\Component\Video\VideoInterface;
 use Refinery29\Sitemap\Writer\UrlSetWriter;
 use Refinery29\Sitemap\Writer\UrlWriter;
 
-class UrlSetWriterTest extends AbstractTestCase
+final class UrlSetWriterTest extends AbstractTestCase
 {
     public function testConstructorCreatesRequiredWriter()
     {

--- a/test/Unit/Writer/UrlWriterTest.php
+++ b/test/Unit/Writer/UrlWriterTest.php
@@ -18,7 +18,7 @@ use Refinery29\Sitemap\Writer\News\NewsWriter;
 use Refinery29\Sitemap\Writer\UrlWriter;
 use Refinery29\Sitemap\Writer\Video\VideoWriter;
 
-class UrlWriterTest extends AbstractTestCase
+final class UrlWriterTest extends AbstractTestCase
 {
     public function testWriteSimpleUrl()
     {

--- a/test/Unit/Writer/Video/GalleryLocationWriterTest.php
+++ b/test/Unit/Writer/Video/GalleryLocationWriterTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Video\GalleryLocationInterface;
 use Refinery29\Sitemap\Test\Unit\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\Video\GalleryLocationWriter;
 
-class GalleryLocationWriterTest extends AbstractTestCase
+final class GalleryLocationWriterTest extends AbstractTestCase
 {
     public function testWriteSimpleGalleryLocation()
     {

--- a/test/Unit/Writer/Video/PlatformWriterTest.php
+++ b/test/Unit/Writer/Video/PlatformWriterTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Video\PlatformInterface;
 use Refinery29\Sitemap\Test\Unit\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\Video\PlatformWriter;
 
-class PlatformWriterTest extends AbstractTestCase
+final class PlatformWriterTest extends AbstractTestCase
 {
     public function testWritePlatform()
     {

--- a/test/Unit/Writer/Video/PlayerLocationWriterTest.php
+++ b/test/Unit/Writer/Video/PlayerLocationWriterTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Video\PlayerLocationInterface;
 use Refinery29\Sitemap\Test\Unit\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\Video\PlayerLocationWriter;
 
-class PlayerLocationWriterTest extends AbstractTestCase
+final class PlayerLocationWriterTest extends AbstractTestCase
 {
     public function testWriteSimplePlayerLocation()
     {

--- a/test/Unit/Writer/Video/PriceWriterTest.php
+++ b/test/Unit/Writer/Video/PriceWriterTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Video\PriceInterface;
 use Refinery29\Sitemap\Test\Unit\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\Video\PriceWriter;
 
-class PriceWriterTest extends AbstractTestCase
+final class PriceWriterTest extends AbstractTestCase
 {
     public function testWriteWithSimplePrice()
     {

--- a/test/Unit/Writer/Video/RestrictionWriterTest.php
+++ b/test/Unit/Writer/Video/RestrictionWriterTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Video\RestrictionInterface;
 use Refinery29\Sitemap\Test\Unit\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\Video\RestrictionWriter;
 
-class RestrictionWriterTest extends AbstractTestCase
+final class RestrictionWriterTest extends AbstractTestCase
 {
     public function testWriteRestriction()
     {

--- a/test/Unit/Writer/Video/TagWriterTest.php
+++ b/test/Unit/Writer/Video/TagWriterTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Video\TagInterface;
 use Refinery29\Sitemap\Test\Unit\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\Video\TagWriter;
 
-class TagWriterTest extends AbstractTestCase
+final class TagWriterTest extends AbstractTestCase
 {
     public function testWriteWithSimpleUploader()
     {

--- a/test/Unit/Writer/Video/UploaderWriterTest.php
+++ b/test/Unit/Writer/Video/UploaderWriterTest.php
@@ -13,7 +13,7 @@ use Refinery29\Sitemap\Component\Video\UploaderInterface;
 use Refinery29\Sitemap\Test\Unit\Writer\AbstractTestCase;
 use Refinery29\Sitemap\Writer\Video\UploaderWriter;
 
-class UploaderWriterTest extends AbstractTestCase
+final class UploaderWriterTest extends AbstractTestCase
 {
     public function testWriteWithSimpleUploader()
     {

--- a/test/Unit/Writer/Video/VideoWriterTest.php
+++ b/test/Unit/Writer/Video/VideoWriterTest.php
@@ -27,7 +27,7 @@ use Refinery29\Sitemap\Writer\Video\TagWriter;
 use Refinery29\Sitemap\Writer\Video\UploaderWriter;
 use Refinery29\Sitemap\Writer\Video\VideoWriter;
 
-class VideoWriterTest extends AbstractTestCase
+final class VideoWriterTest extends AbstractTestCase
 {
     public function testConstructorCreatesRequiredWriters()
     {


### PR DESCRIPTION
This PR

* [x] marks test classes as `final`
* [x] marks methods in `AbstractTestCase` as `final`
