### PR TITLE
Fix: Use createMock() instead of deprecated getMock()

### DIFF
--- a/test/Unit/Component/News/NewsTest.php
+++ b/test/Unit/Component/News/NewsTest.php
@@ -449,6 +449,6 @@ final class NewsTest extends \PHPUnit_Framework_TestCase
      */
     private function getPublicationMock()
     {
-        return $this->getMock(PublicationInterface::class);
+        return $this->createMock(PublicationInterface::class);
     }
 }

--- a/test/Unit/Component/SitemapIndexTest.php
+++ b/test/Unit/Component/SitemapIndexTest.php
@@ -85,6 +85,6 @@ final class SitemapIndexTest extends \PHPUnit_Framework_TestCase
      */
     private function getSitemapMock()
     {
-        return $this->getMock(SitemapInterface::class);
+        return $this->createMock(SitemapInterface::class);
     }
 }

--- a/test/Unit/Component/UrlSetTest.php
+++ b/test/Unit/Component/UrlSetTest.php
@@ -69,6 +69,6 @@ final class UrlSetTest extends \PHPUnit_Framework_TestCase
      */
     private function getUrlMock()
     {
-        return $this->getMock(UrlInterface::class);
+        return $this->createMock(UrlInterface::class);
     }
 }

--- a/test/Unit/Component/UrlTest.php
+++ b/test/Unit/Component/UrlTest.php
@@ -400,7 +400,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     private function getImageMock()
     {
-        return $this->getMock(ImageInterface::class);
+        return $this->createMock(ImageInterface::class);
     }
 
     /**
@@ -408,7 +408,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     private function getNewsMock()
     {
-        return $this->getMock(NewsInterface::class);
+        return $this->createMock(NewsInterface::class);
     }
 
     /**
@@ -416,6 +416,6 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     private function getVideoMock()
     {
-        return $this->getMock(VideoInterface::class);
+        return $this->createMock(VideoInterface::class);
     }
 }

--- a/test/Unit/Component/Video/VideoTest.php
+++ b/test/Unit/Component/Video/VideoTest.php
@@ -923,7 +923,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     private function getGalleryLocationMock()
     {
-        return $this->getMock(GalleryLocationInterface::class);
+        return $this->createMock(GalleryLocationInterface::class);
     }
 
     /**
@@ -931,7 +931,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     private function getPlatformMock()
     {
-        return $this->getMock(PlatformInterface::class);
+        return $this->createMock(PlatformInterface::class);
     }
 
     /**
@@ -939,7 +939,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     private function getPlayerLocationMock()
     {
-        return $this->getMock(PlayerLocationInterface::class);
+        return $this->createMock(PlayerLocationInterface::class);
     }
 
     /**
@@ -947,7 +947,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     private function getPriceMock()
     {
-        return $this->getMock(PriceInterface::class);
+        return $this->createMock(PriceInterface::class);
     }
 
     /**
@@ -955,7 +955,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     private function getRestrictionMock()
     {
-        return $this->getMock(RestrictionInterface::class);
+        return $this->createMock(RestrictionInterface::class);
     }
 
     /**
@@ -963,7 +963,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     private function getTagMock()
     {
-        return $this->getMock(TagInterface::class);
+        return $this->createMock(TagInterface::class);
     }
 
     /**
@@ -971,6 +971,6 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     private function getUploaderMock()
     {
-        return $this->getMock(UploaderInterface::class);
+        return $this->createMock(UploaderInterface::class);
     }
 }

--- a/test/Unit/Writer/Image/ImageWriterTest.php
+++ b/test/Unit/Writer/Image/ImageWriterTest.php
@@ -82,7 +82,7 @@ final class ImageWriterTest extends AbstractTestCase
      */
     private function getImageMock($location, $title = null, $caption = null, $geoLocation = null, $licence = null)
     {
-        $image = $this->getMock(ImageInterface::class);
+        $image = $this->createMock(ImageInterface::class);
 
         $image
             ->expects($this->any())
@@ -117,6 +117,6 @@ final class ImageWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/News/NewsWriterTest.php
+++ b/test/Unit/Writer/News/NewsWriterTest.php
@@ -133,7 +133,7 @@ final class NewsWriterTest extends AbstractTestCase
         array $keywords = [],
         array $stockTickers = []
     ) {
-        $news = $this->getMock(NewsInterface::class);
+        $news = $this->createMock(NewsInterface::class);
 
         $news
             ->expects($this->any())
@@ -178,7 +178,7 @@ final class NewsWriterTest extends AbstractTestCase
      */
     private function getPublicationMock()
     {
-        return $this->getMock(PublicationInterface::class);
+        return $this->createMock(PublicationInterface::class);
     }
 
     /**
@@ -186,7 +186,7 @@ final class NewsWriterTest extends AbstractTestCase
      */
     private function getPublicationWriterMock()
     {
-        return $this->getMock(PublicationWriter::class);
+        return $this->createMock(PublicationWriter::class);
     }
 
     /**
@@ -194,6 +194,6 @@ final class NewsWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/News/PublicationWriterTest.php
+++ b/test/Unit/Writer/News/PublicationWriterTest.php
@@ -49,7 +49,7 @@ final class PublicationWriterTest extends AbstractTestCase
      */
     private function getPublicationMock($name, $language)
     {
-        $publication = $this->getMock(PublicationInterface::class);
+        $publication = $this->createMock(PublicationInterface::class);
 
         $publication
             ->expects($this->any())
@@ -69,6 +69,6 @@ final class PublicationWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/SitemapIndexWriterTest.php
+++ b/test/Unit/Writer/SitemapIndexWriterTest.php
@@ -72,7 +72,7 @@ final class SitemapIndexWriterTest extends AbstractTestCase
      */
     private function getSitemapIndexMock(array $sitemaps = [])
     {
-        $sitemapIndex = $this->getMock(SitemapIndexInterface::class);
+        $sitemapIndex = $this->createMock(SitemapIndexInterface::class);
 
         $sitemapIndex
             ->expects($this->any())
@@ -87,7 +87,7 @@ final class SitemapIndexWriterTest extends AbstractTestCase
      */
     private function getSitemapMock()
     {
-        return $this->getMock(SitemapInterface::class);
+        return $this->createMock(SitemapInterface::class);
     }
 
     /**
@@ -95,7 +95,7 @@ final class SitemapIndexWriterTest extends AbstractTestCase
      */
     private function getSitemapWriterMock()
     {
-        return $this->getMock(SitemapWriter::class);
+        return $this->createMock(SitemapWriter::class);
     }
 
     /**
@@ -103,6 +103,6 @@ final class SitemapIndexWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/SitemapWriterTest.php
+++ b/test/Unit/Writer/SitemapWriterTest.php
@@ -69,7 +69,7 @@ final class SitemapWriterTest extends AbstractTestCase
      */
     private function getSitemapMock($location, \DateTime $lastModified = null)
     {
-        $sitemap = $this->getMock(SitemapInterface::class);
+        $sitemap = $this->createMock(SitemapInterface::class);
 
         $sitemap
             ->expects($this->any())
@@ -89,6 +89,6 @@ final class SitemapWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/UrlSetWriterTest.php
+++ b/test/Unit/Writer/UrlSetWriterTest.php
@@ -75,7 +75,7 @@ final class UrlSetWriterTest extends AbstractTestCase
      */
     private function getUrlMock()
     {
-        return $this->getMock(UrlInterface::class);
+        return $this->createMock(UrlInterface::class);
     }
 
     /**
@@ -85,7 +85,7 @@ final class UrlSetWriterTest extends AbstractTestCase
      */
     private function getUrlSetMock(array $urls = [])
     {
-        $urlSet = $this->getMock(UrlSetInterface::class);
+        $urlSet = $this->createMock(UrlSetInterface::class);
 
         $urlSet
             ->expects($this->any())
@@ -110,6 +110,6 @@ final class UrlSetWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/UrlWriterTest.php
+++ b/test/Unit/Writer/UrlWriterTest.php
@@ -134,7 +134,7 @@ final class UrlWriterTest extends AbstractTestCase
         array $news = [],
         array $videos = []
     ) {
-        $url = $this->getMock(UrlInterface::class);
+        $url = $this->createMock(UrlInterface::class);
 
         $url
             ->expects($this->any())
@@ -179,7 +179,7 @@ final class UrlWriterTest extends AbstractTestCase
      */
     private function getImageMock()
     {
-        return $this->getMock(ImageInterface::class);
+        return $this->createMock(ImageInterface::class);
     }
 
     /**
@@ -187,7 +187,7 @@ final class UrlWriterTest extends AbstractTestCase
      */
     private function getImageWriterMock()
     {
-        return $this->getMock(ImageWriter::class);
+        return $this->createMock(ImageWriter::class);
     }
 
     /**
@@ -218,7 +218,7 @@ final class UrlWriterTest extends AbstractTestCase
      */
     private function getNewsMock()
     {
-        return $this->getMock(NewsInterface::class);
+        return $this->createMock(NewsInterface::class);
     }
 
     /**
@@ -259,7 +259,7 @@ final class UrlWriterTest extends AbstractTestCase
      */
     private function getVideoMock()
     {
-        return $this->getMock(VideoInterface::class);
+        return $this->createMock(VideoInterface::class);
     }
 
     /**
@@ -300,6 +300,6 @@ final class UrlWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/GalleryLocationWriterTest.php
+++ b/test/Unit/Writer/Video/GalleryLocationWriterTest.php
@@ -63,7 +63,7 @@ final class GalleryLocationWriterTest extends AbstractTestCase
      */
     private function getGalleryLocationMock($location, $title = null)
     {
-        $galleryLocation = $this->getMock(GalleryLocationInterface::class);
+        $galleryLocation = $this->createMock(GalleryLocationInterface::class);
 
         $galleryLocation
             ->expects($this->any())
@@ -83,6 +83,6 @@ final class GalleryLocationWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/PlatformWriterTest.php
+++ b/test/Unit/Writer/Video/PlatformWriterTest.php
@@ -54,7 +54,7 @@ final class PlatformWriterTest extends AbstractTestCase
      */
     private function getPlatformMock($relationship, array $types)
     {
-        $platform = $this->getMock(PlatformInterface::class);
+        $platform = $this->createMock(PlatformInterface::class);
 
         $platform
             ->expects($this->any())
@@ -74,6 +74,6 @@ final class PlatformWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/PlayerLocationWriterTest.php
+++ b/test/Unit/Writer/Video/PlayerLocationWriterTest.php
@@ -70,7 +70,7 @@ final class PlayerLocationWriterTest extends AbstractTestCase
      */
     private function getPlayerLocationMock($location, $allowEmbed = null, $autoPlay = null)
     {
-        $playerLocation = $this->getMock(PlayerLocationInterface::class);
+        $playerLocation = $this->createMock(PlayerLocationInterface::class);
 
         $playerLocation
             ->expects($this->any())
@@ -95,6 +95,6 @@ final class PlayerLocationWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/PriceWriterTest.php
+++ b/test/Unit/Writer/Video/PriceWriterTest.php
@@ -89,7 +89,7 @@ final class PriceWriterTest extends AbstractTestCase
      */
     private function getPriceMock($currency, $value, $type = null, $resolution = null)
     {
-        $price = $this->getMock(PriceInterface::class);
+        $price = $this->createMock(PriceInterface::class);
 
         $price
             ->expects($this->any())
@@ -119,6 +119,6 @@ final class PriceWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/RestrictionWriterTest.php
+++ b/test/Unit/Writer/Video/RestrictionWriterTest.php
@@ -54,7 +54,7 @@ final class RestrictionWriterTest extends AbstractTestCase
      */
     private function getRestrictionMock($relationship, array $countryCodes)
     {
-        $restriction = $this->getMock(RestrictionInterface::class);
+        $restriction = $this->createMock(RestrictionInterface::class);
 
         $restriction
             ->expects($this->any())
@@ -74,6 +74,6 @@ final class RestrictionWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/TagWriterTest.php
+++ b/test/Unit/Writer/Video/TagWriterTest.php
@@ -37,7 +37,7 @@ final class TagWriterTest extends AbstractTestCase
      */
     private function getTagMock($content)
     {
-        $tag = $this->getMock(TagInterface::class);
+        $tag = $this->createMock(TagInterface::class);
 
         $tag
             ->expects($this->any())
@@ -52,6 +52,6 @@ final class TagWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/UploaderWriterTest.php
+++ b/test/Unit/Writer/Video/UploaderWriterTest.php
@@ -61,7 +61,7 @@ final class UploaderWriterTest extends AbstractTestCase
      */
     private function getUploaderMock($name, $info = null)
     {
-        $uploader = $this->getMock(UploaderInterface::class);
+        $uploader = $this->createMock(UploaderInterface::class);
 
         $uploader
             ->expects($this->any())
@@ -81,6 +81,6 @@ final class UploaderWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }

--- a/test/Unit/Writer/Video/VideoWriterTest.php
+++ b/test/Unit/Writer/Video/VideoWriterTest.php
@@ -237,7 +237,7 @@ final class VideoWriterTest extends AbstractTestCase
         array $prices = [],
         array $tags = []
     ) {
-        $video = $this->getMock(VideoInterface::class);
+        $video = $this->createMock(VideoInterface::class);
 
         $video
             ->expects($this->any())
@@ -347,7 +347,7 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getGalleryLocationMock()
     {
-        return $this->getMock(GalleryLocationInterface::class);
+        return $this->createMock(GalleryLocationInterface::class);
     }
 
     /**
@@ -355,7 +355,7 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getGalleryLocationWriterMock()
     {
-        return $this->getMock(GalleryLocationWriter::class);
+        return $this->createMock(GalleryLocationWriter::class);
     }
 
     /**
@@ -384,7 +384,7 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getPlatformMock()
     {
-        return $this->getMock(PlatformInterface::class);
+        return $this->createMock(PlatformInterface::class);
     }
 
     /**
@@ -392,7 +392,7 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getPlatformWriterMock()
     {
-        return $this->getMock(PlatformWriter::class);
+        return $this->createMock(PlatformWriter::class);
     }
 
     /**
@@ -421,7 +421,7 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getPlayerLocationMock()
     {
-        return $this->getMock(PlayerLocationInterface::class);
+        return $this->createMock(PlayerLocationInterface::class);
     }
 
     /**
@@ -429,7 +429,7 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getPlayerLocationWriterMock()
     {
-        return $this->getMock(PlayerLocationWriter::class);
+        return $this->createMock(PlayerLocationWriter::class);
     }
 
     /**
@@ -458,7 +458,7 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getPriceMock()
     {
-        return $this->getMock(PriceInterface::class);
+        return $this->createMock(PriceInterface::class);
     }
 
     /**
@@ -466,7 +466,7 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getPriceWriterMock()
     {
-        return $this->getMock(PriceWriter::class);
+        return $this->createMock(PriceWriter::class);
     }
 
     /**
@@ -497,7 +497,7 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getRestrictionMock()
     {
-        return $this->getMock(RestrictionInterface::class);
+        return $this->createMock(RestrictionInterface::class);
     }
 
     /**
@@ -505,7 +505,7 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getRestrictionWriterMock()
     {
-        return $restrictionWriter = $this->getMock(RestrictionWriter::class);
+        return $restrictionWriter = $this->createMock(RestrictionWriter::class);
     }
 
     /**
@@ -534,7 +534,7 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getTagMock()
     {
-        return $this->getMock(TagInterface::class);
+        return $this->createMock(TagInterface::class);
     }
 
     /**
@@ -542,7 +542,7 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getTagWriterMock()
     {
-        return $this->getMock(TagWriter::class);
+        return $this->createMock(TagWriter::class);
     }
 
     /**
@@ -573,7 +573,7 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getUploaderMock()
     {
-        return $this->getMock(UploaderInterface::class);
+        return $this->createMock(UploaderInterface::class);
     }
 
     /**
@@ -602,7 +602,7 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getUploaderWriterMock()
     {
-        return $this->getMock(UploaderWriter::class);
+        return $this->createMock(UploaderWriter::class);
     }
 
     /**
@@ -610,6 +610,6 @@ final class VideoWriterTest extends AbstractTestCase
      */
     private function getXmlWriterMock()
     {
-        return $this->getMock(\XMLWriter::class);
+        return $this->createMock(\XMLWriter::class);
     }
 }


### PR DESCRIPTION
This PR

* [x] uses `createMock()` instead of deprecated `getMock()`

Follows #152.
