### PR TITLE
Fix: Use createMock() instead of getMockBuilder() where possible

### DIFF
--- a/test/Unit/Writer/UrlSetWriterTest.php
+++ b/test/Unit/Writer/UrlSetWriterTest.php
@@ -100,9 +100,7 @@ final class UrlSetWriterTest extends AbstractTestCase
      */
     private function getUrlWriterMock()
     {
-        return $this->getMockBuilder(UrlWriter::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(UrlWriter::class);
     }
 
     /**

--- a/test/Unit/Writer/UrlWriterTest.php
+++ b/test/Unit/Writer/UrlWriterTest.php
@@ -226,9 +226,7 @@ final class UrlWriterTest extends AbstractTestCase
      */
     private function getNewsWriterMock()
     {
-        return $this->getMockBuilder(NewsWriter::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(NewsWriter::class);
     }
 
     /**
@@ -267,9 +265,7 @@ final class UrlWriterTest extends AbstractTestCase
      */
     private function getVideoWriterMock()
     {
-        return $this->getMockBuilder(VideoWriter::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(VideoWriter::class);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] uses `createMock()` instead of `getMockBuilder()` where possible

Follows #152.