### PR TITLE
Fix: Use expectException() instead of deprecated setExpectedException()

### DIFF
--- a/test/Unit/Component/Image/ImageTest.php
+++ b/test/Unit/Component/Image/ImageTest.php
@@ -50,7 +50,7 @@ final class ImageTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidValue($location)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         new Image($location);
     }
@@ -71,7 +71,7 @@ final class ImageTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithTitleRejectsInvalidValue($title)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $location = $this->getFaker()->url;
 
@@ -87,7 +87,7 @@ final class ImageTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithTitleRejectsEmptyString($title)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $location = $this->getFaker()->url;
 
@@ -118,7 +118,7 @@ final class ImageTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithCaptionRejectsInvalidValue($caption)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $location = $this->getFaker()->url;
 
@@ -134,7 +134,7 @@ final class ImageTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithCaptionRejectsEmptyString($caption)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $location = $this->getFaker()->url;
 
@@ -165,7 +165,7 @@ final class ImageTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithGeoLocationRejectsInvalidValue($geoLocation)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $location = $this->getFaker()->url;
 
@@ -181,7 +181,7 @@ final class ImageTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithGeoLocationRejectsBlankString($geoLocation)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $location = $this->getFaker()->url;
 
@@ -212,7 +212,7 @@ final class ImageTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithLicenceRejectsInvalidValue($licence)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $location = $this->getFaker()->url;
 
@@ -228,7 +228,7 @@ final class ImageTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithLicenceRejectsBlankString($licence)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $location = $this->getFaker()->url;
 

--- a/test/Unit/Component/News/NewsTest.php
+++ b/test/Unit/Component/News/NewsTest.php
@@ -61,7 +61,7 @@ final class NewsTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidTitle($title)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -79,7 +79,7 @@ final class NewsTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsBlankTitle($title)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -116,7 +116,7 @@ final class NewsTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithAccessRejectsInvalidValue($access)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -175,7 +175,7 @@ final class NewsTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithGenresRejectsInvalidValues($genre)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -196,7 +196,7 @@ final class NewsTest extends \PHPUnit_Framework_TestCase
 
     public function testWithGenresRejectsUnknownValues()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -222,7 +222,7 @@ final class NewsTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithGenresRejectsDuplicateValues($genre)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -292,7 +292,7 @@ final class NewsTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithKeywordsRejectsInvalidValues($keyword)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -318,7 +318,7 @@ final class NewsTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithKeywordsRejectsBlankValues($keyword)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -363,7 +363,7 @@ final class NewsTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithStockTickersRejectsInvalidValues($stockTicker)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -389,7 +389,7 @@ final class NewsTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithStockTickersRejectsBlankValues($stockTicker)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -410,7 +410,7 @@ final class NewsTest extends \PHPUnit_Framework_TestCase
 
     public function testWithStockTickersRejectsTooManyValues()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 

--- a/test/Unit/Component/News/PublicationTest.php
+++ b/test/Unit/Component/News/PublicationTest.php
@@ -38,7 +38,7 @@ final class PublicationTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidName($name)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $language = $this->getFaker()->languageCode;
 
@@ -55,7 +55,7 @@ final class PublicationTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsBlankName($name)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $language = $this->getFaker()->languageCode;
 
@@ -72,7 +72,7 @@ final class PublicationTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidLanguage($language)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $name = $this->getFaker()->sentence();
 
@@ -89,7 +89,7 @@ final class PublicationTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsBlankLanguage($language)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $name = $this->getFaker()->sentence();
 

--- a/test/Unit/Component/SitemapIndexTest.php
+++ b/test/Unit/Component/SitemapIndexTest.php
@@ -39,7 +39,7 @@ final class SitemapIndexTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidValue($value)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         new SitemapIndex($value);
     }

--- a/test/Unit/Component/SitemapTest.php
+++ b/test/Unit/Component/SitemapTest.php
@@ -48,7 +48,7 @@ final class SitemapTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidValue($location)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         new Sitemap($location);
     }

--- a/test/Unit/Component/UrlSetTest.php
+++ b/test/Unit/Component/UrlSetTest.php
@@ -27,7 +27,7 @@ final class UrlSetTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorRejectsInvalidValue()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $urls = [
             $this->getUrlMock(),
@@ -40,7 +40,7 @@ final class UrlSetTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorRejectsTooManyValues()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $urls = array_fill(
             0,

--- a/test/Unit/Component/UrlTest.php
+++ b/test/Unit/Component/UrlTest.php
@@ -58,7 +58,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidValue($location)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         new Url($location);
     }
@@ -95,7 +95,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithChangeFrequencyRejectsInvalidValue($changeFrequency)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $url = new Url($this->getFaker()->url);
 
@@ -149,7 +149,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithPriorityRejectsInvalidValue($priority)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $url = new Url($this->getFaker()->url);
 
@@ -163,7 +163,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithPriorityRejectsOutOfBoundsValue($priority)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $url = new Url($this->getFaker()->url);
 
@@ -234,7 +234,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithImagesRejectsInvalidValue($images)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -290,7 +290,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithNewsRejectsInvalidValue($news)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -346,7 +346,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithVideosRejectsInvalidValue($videos)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 

--- a/test/Unit/Component/Video/GalleryLocationTest.php
+++ b/test/Unit/Component/Video/GalleryLocationTest.php
@@ -45,7 +45,7 @@ final class GalleryLocationTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidValue($location)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         new GalleryLocation($location);
     }
@@ -68,7 +68,7 @@ final class GalleryLocationTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithTitleRejectsInvalidValue($title)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $location = $this->getFaker()->url;
 
@@ -84,7 +84,7 @@ final class GalleryLocationTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithTitleRejectsBlankString($title)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $location = $this->getFaker()->url;
 

--- a/test/Unit/Component/Video/PlatformTest.php
+++ b/test/Unit/Component/Video/PlatformTest.php
@@ -49,7 +49,7 @@ final class PlatformTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidValue($relationship)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         new Platform($relationship);
     }
@@ -90,7 +90,7 @@ final class PlatformTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithTypesRejectsInvalidValues($type)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -110,7 +110,7 @@ final class PlatformTest extends \PHPUnit_Framework_TestCase
 
     public function testWithTypesRejectsUnknownValues()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -135,7 +135,7 @@ final class PlatformTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithTypesRejectsDuplicateValues($type)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 

--- a/test/Unit/Component/Video/PlayerLocationTest.php
+++ b/test/Unit/Component/Video/PlayerLocationTest.php
@@ -52,7 +52,7 @@ final class PlayerLocationTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidLocation($location)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         new PlayerLocation($location);
     }
@@ -75,7 +75,7 @@ final class PlayerLocationTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithAllowEmbedRejectsInvalidValues($allowEmbed)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -86,7 +86,7 @@ final class PlayerLocationTest extends \PHPUnit_Framework_TestCase
 
     public function testWithAllowEmbedRejectsUnknownValues()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 

--- a/test/Unit/Component/Video/PriceTest.php
+++ b/test/Unit/Component/Video/PriceTest.php
@@ -54,7 +54,7 @@ final class PriceTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidValue($value)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         new Price(
             $value,
@@ -64,7 +64,7 @@ final class PriceTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorRejectsTooSmallValue()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $value = PriceInterface::VALUE_MIN - 0.01;
 
@@ -102,7 +102,7 @@ final class PriceTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithTypeRejectsInvalidValue($type)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -119,7 +119,7 @@ final class PriceTest extends \PHPUnit_Framework_TestCase
 
     public function testWithTypeRejectsUnknownValue()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -181,7 +181,7 @@ final class PriceTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithResolutionRejectsInvalidValue($resolution)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -198,7 +198,7 @@ final class PriceTest extends \PHPUnit_Framework_TestCase
 
     public function testWithResolutionRejectsUnknownValue()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 

--- a/test/Unit/Component/Video/RestrictionTest.php
+++ b/test/Unit/Component/Video/RestrictionTest.php
@@ -51,14 +51,14 @@ final class RestrictionTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidValue($restriction)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         new Restriction($restriction);
     }
 
     public function testConstructorRejectsUnknownValue()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $relationship = $this->getFaker()->sentence();
 
@@ -101,7 +101,7 @@ final class RestrictionTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithCountryCodeRejectsInvalidCountryCodes($countryCode)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -126,7 +126,7 @@ final class RestrictionTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithCountryCodeRejectsBlankCountryCodes($countryCode)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 

--- a/test/Unit/Component/Video/TagTest.php
+++ b/test/Unit/Component/Video/TagTest.php
@@ -38,7 +38,7 @@ final class TagTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidValue($content)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         new Tag($content);
     }
@@ -50,7 +50,7 @@ final class TagTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsBlankString($content)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         new Tag($content);
     }

--- a/test/Unit/Component/Video/UploaderTest.php
+++ b/test/Unit/Component/Video/UploaderTest.php
@@ -45,7 +45,7 @@ final class UploaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidValue($name)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         new Uploader($name);
     }
@@ -57,7 +57,7 @@ final class UploaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsBlankString($name)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         new Uploader($name);
     }
@@ -80,7 +80,7 @@ final class UploaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithInfoRejectsInvalidValue($info)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $uploader = new Uploader($this->getFaker()->url);
 
@@ -94,7 +94,7 @@ final class UploaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithInfoRejectsBlankString($info)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $uploader = new Uploader($this->getFaker()->url);
 

--- a/test/Unit/Component/Video/VideoTest.php
+++ b/test/Unit/Component/Video/VideoTest.php
@@ -70,7 +70,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorRejectsTitleLongerThanMaxLength()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -86,7 +86,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorRejectsDescriptionLongerThanMaxLength()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -102,7 +102,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorRejectsInvalidCombinationOfContentAndPlayerLocation()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -168,7 +168,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithDurationRejectsInvalidValue($duration)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -190,7 +190,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithDurationRejectsOutOfBoundsValue($duration)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -299,7 +299,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithRatingRejectsInvalidValue($rating)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -321,7 +321,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithRatingRejectsOutOfBoundsValue($rating)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -385,7 +385,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithViewCountRejectsInvalidValue($viewCount)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -402,7 +402,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
 
     public function testWithViewCountRejectsNegativeValue()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -447,7 +447,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithFamilyFriendlyRejectsInvalidValue($familyFriendly)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -464,7 +464,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
 
     public function testWithFamilyFriendlyRejectsUnknownValue()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -509,7 +509,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithTagsRejectsInvalidValue($tag)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -532,7 +532,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
 
     public function testWithTagsRejectsTooManyValues()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -585,7 +585,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithCategoryRejectsInvalidValue($category)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -602,7 +602,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
 
     public function testWithCategoryRejectsTooLongValue()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -666,7 +666,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
 
     public function testWithPricesRejectsInvalidValue()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -719,7 +719,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithRequiresSubscriptionRejectsInvalidValue($requiresSubscription)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -736,7 +736,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
 
     public function testWithRequiresSubscriptionRejectsUnknownValue()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -843,7 +843,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithLiveRejectsInvalidValue($live)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 
@@ -860,7 +860,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
 
     public function testWithLiveRejectsUnknownValue()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $faker = $this->getFaker();
 


### PR DESCRIPTION
This PR

* [x] uses `expecteException()` instead of deprecated `setExpectedException()`

Follows #152.
