### PR TITLE
Fix: Use provideData()

### DIFF
--- a/test/Unit/Component/News/NewsTest.php
+++ b/test/Unit/Component/News/NewsTest.php
@@ -154,16 +154,10 @@ final class NewsTest extends \PHPUnit_Framework_TestCase
      */
     public function providerAccess()
     {
-        $values = [
+        return $this->provideData([
             NewsInterface::ACCESS_REGISTRATION,
             NewsInterface::ACCESS_SUBSCRIPTION,
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     /**
@@ -268,19 +262,13 @@ final class NewsTest extends \PHPUnit_Framework_TestCase
      */
     public function providerGenre()
     {
-        $values = [
+        return $this->provideData([
             NewsInterface::GENRE_BLOG,
             NewsInterface::GENRE_OP_ED,
             NewsInterface::GENRE_OPINION,
             NewsInterface::GENRE_SATIRE,
             NewsInterface::GENRE_USER_GENERATED,
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     /**

--- a/test/Unit/Component/SitemapIndexTest.php
+++ b/test/Unit/Component/SitemapIndexTest.php
@@ -49,20 +49,14 @@ final class SitemapIndexTest extends \PHPUnit_Framework_TestCase
     {
         $faker = $this->getFaker();
 
-        $values = [
+        return $this->provideData([
             $faker->words(),
             [
                 $this->getSitemapMock(),
                 $this->getSitemapMock(),
                 new \stdClass(),
             ],
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     public function testConstructorSetsValue()

--- a/test/Unit/Component/UrlTest.php
+++ b/test/Unit/Component/UrlTest.php
@@ -123,7 +123,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function providerChangeFrequency()
     {
-        $values = [
+        return $this->provideData([
             UrlInterface::CHANGE_FREQUENCY_ALWAYS,
             UrlInterface::CHANGE_FREQUENCY_HOURLY,
             UrlInterface::CHANGE_FREQUENCY_DAILY,
@@ -131,13 +131,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
             UrlInterface::CHANGE_FREQUENCY_MONTHLY,
             UrlInterface::CHANGE_FREQUENCY_YEARLY,
             UrlInterface::CHANGE_FREQUENCY_NEVER,
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     /**
@@ -173,16 +167,10 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function providerOutOfBoundsPriority()
     {
-        $values = [
+        return $this->provideData([
             UrlInterface::PRIORITY_MIN - 0.1,
             UrlInterface::PRIORITY_MAX + 0.1,
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     /**
@@ -208,7 +196,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function providerPriority()
     {
-        $values = [
+        return $this->provideData([
             UrlInterface::PRIORITY_MAX,
             UrlInterface::PRIORITY_MIN,
             $this->getFaker()->randomFloat(
@@ -216,13 +204,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
                 UrlInterface::PRIORITY_MIN,
                 UrlInterface::PRIORITY_MAX
             ),
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     /**
@@ -246,20 +228,14 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function providerInvalidImages()
     {
-        $values = [
+        return $this->provideData([
             $this->getFaker()->words,
             [
                 $this->getImageMock(),
                 $this->getImageMock(),
                 new \stdClass(),
             ],
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     public function testWithImagesClonesObjectAndSetsValue()
@@ -302,20 +278,14 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function providerInvalidNews()
     {
-        $values = [
+        return $this->provideData([
             $this->getFaker()->words,
             [
                 $this->getNewsMock(),
                 $this->getNewsMock(),
                 new \stdClass(),
             ],
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     public function testWithNewsClonesObjectAndSetsValue()
@@ -358,20 +328,14 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function providerInvalidVideos()
     {
-        $values = [
+        return $this->provideData([
             $this->getFaker()->words,
             [
                 $this->getVideoMock(),
                 $this->getVideoMock(),
                 new \stdClass(),
             ],
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     public function testWithVideosClonesObjectAndSetsValue()

--- a/test/Unit/Component/Video/PlatformTest.php
+++ b/test/Unit/Component/Video/PlatformTest.php
@@ -69,16 +69,10 @@ final class PlatformTest extends \PHPUnit_Framework_TestCase
      */
     public function providerRelationship()
     {
-        $values = [
+        return $this->provideData([
             PlatformInterface::RELATIONSHIP_ALLOW,
             PlatformInterface::RELATIONSHIP_DENY,
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     /**
@@ -155,17 +149,11 @@ final class PlatformTest extends \PHPUnit_Framework_TestCase
      */
     public function providerType()
     {
-        $values = [
+        return $this->provideData([
             PlatformInterface::TYPE_MOBILE,
             PlatformInterface::TYPE_TV,
             PlatformInterface::TYPE_WEB,
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     public function testWithTypesClonesObjectAndSetsValue()

--- a/test/Unit/Component/Video/PlayerLocationTest.php
+++ b/test/Unit/Component/Video/PlayerLocationTest.php
@@ -118,16 +118,10 @@ final class PlayerLocationTest extends \PHPUnit_Framework_TestCase
      */
     public function providerAllowEmbed()
     {
-        $values = [
+        return $this->provideData([
             PlayerLocationInterface::ALLOW_EMBED_NO,
             PlayerLocationInterface::ALLOW_EMBED_YES,
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     /**

--- a/test/Unit/Component/Video/PriceTest.php
+++ b/test/Unit/Component/Video/PriceTest.php
@@ -160,16 +160,10 @@ final class PriceTest extends \PHPUnit_Framework_TestCase
      */
     public function providerType()
     {
-        $values = [
+        return $this->provideData([
             PriceInterface::TYPE_OWN,
             PriceInterface::TYPE_RENT,
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     /**
@@ -242,15 +236,9 @@ final class PriceTest extends \PHPUnit_Framework_TestCase
      */
     public function providerResolution()
     {
-        $values = [
+        return $this->provideData([
             PriceInterface::RESOLUTION_HD,
             PriceInterface::RESOLUTION_SD,
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 }

--- a/test/Unit/Component/Video/RestrictionTest.php
+++ b/test/Unit/Component/Video/RestrictionTest.php
@@ -80,16 +80,10 @@ final class RestrictionTest extends \PHPUnit_Framework_TestCase
      */
     public function providerRelationship()
     {
-        $values = [
+        return $this->provideData([
             RestrictionInterface::RELATIONSHIP_ALLOW,
             RestrictionInterface::RELATIONSHIP_DENY,
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     /**

--- a/test/Unit/Component/Video/VideoTest.php
+++ b/test/Unit/Component/Video/VideoTest.php
@@ -208,18 +208,12 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     public function providerOutOfBoundsDuration()
     {
-        $values = [
+        return $this->provideData([
             VideoInterface::DURATION_LOWER_LIMIT - 1,
             VideoInterface::DURATION_LOWER_LIMIT,
             VideoInterface::DURATION_UPPER_LIMIT,
             VideoInterface::DURATION_UPPER_LIMIT + 1,
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     public function testWithDurationClonesObjectAndSetsValue()
@@ -339,16 +333,10 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     public function providerOutOfBoundsRating()
     {
-        $values = [
+        return $this->provideData([
             VideoInterface::RATING_MIN - 0.1,
             VideoInterface::RATING_MAX + 0.1,
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     public function testWithRatingClonesObjectAndSetsValue()
@@ -780,16 +768,10 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     public function providerRequiresSubscription()
     {
-        $values = [
+        return $this->provideData([
             VideoInterface::REQUIRES_SUBSCRIPTION_NO,
             VideoInterface::REQUIRES_SUBSCRIPTION_YES,
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     public function testWithUploaderClonesObjectAndSetsValue()
@@ -904,16 +886,10 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
      */
     public function providerLive()
     {
-        $values = [
+        return $this->provideData([
             VideoInterface::LIVE_NO,
             VideoInterface::LIVE_YES,
-        ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
+        ]);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] uses `provideData()`

Follows #149.
