### PR TITLE
Fix: Remove need to resolve global function in current namespace

### DIFF
--- a/src/Component/News/News.php
+++ b/src/Component/News/News.php
@@ -141,7 +141,7 @@ final class News implements NewsInterface
         ];
 
         Assertion::allChoice($genres, $choices);
-        Assertion::same($genres, array_unique($genres));
+        Assertion::same($genres, \array_unique($genres));
 
         $instance = clone $this;
 
@@ -180,7 +180,7 @@ final class News implements NewsInterface
     {
         Assertion::allString($stockTickers);
         Assertion::allNotBlank($stockTickers);
-        Assertion::lessOrEqualThan(count($stockTickers), NewsInterface::STOCK_TICKERS_MAX_COUNT);
+        Assertion::lessOrEqualThan(\count($stockTickers), NewsInterface::STOCK_TICKERS_MAX_COUNT);
 
         $instance = clone $this;
 

--- a/src/Component/Url.php
+++ b/src/Component/Url.php
@@ -152,7 +152,7 @@ final class Url implements UrlInterface
         Assertion::float($priority);
         Assertion::greaterOrEqualThan($priority, UrlInterface::PRIORITY_MIN);
         Assertion::lessOrEqualThan($priority, UrlInterface::PRIORITY_MAX);
-        Assertion::same($priority, round($priority, 1));
+        Assertion::same($priority, \round($priority, 1));
 
         $instance = clone $this;
 
@@ -171,7 +171,7 @@ final class Url implements UrlInterface
     public function withImages(array $images)
     {
         Assertion::allIsInstanceOf($images, ImageInterface::class);
-        Assertion::lessOrEqualThan(count($this->images), UrlInterface::IMAGE_MAX_COUNT);
+        Assertion::lessOrEqualThan(\count($this->images), UrlInterface::IMAGE_MAX_COUNT);
 
         $instance = clone $this;
 

--- a/src/Component/UrlSet.php
+++ b/src/Component/UrlSet.php
@@ -26,7 +26,7 @@ final class UrlSet implements UrlSetInterface
     public function __construct(array $urls)
     {
         Assertion::allIsInstanceOf($urls, UrlInterface::class);
-        Assertion::lessOrEqualThan(count($urls), UrlSetInterface::URL_MAX_COUNT);
+        Assertion::lessOrEqualThan(\count($urls), UrlSetInterface::URL_MAX_COUNT);
 
         $this->urls = $urls;
     }

--- a/src/Component/Video/Platform.php
+++ b/src/Component/Video/Platform.php
@@ -66,7 +66,7 @@ final class Platform implements PlatformInterface
         ];
 
         Assertion::allChoice($types, $choices);
-        Assertion::same($types, array_unique($types));
+        Assertion::same($types, \array_unique($types));
 
         $instance = clone $this;
 

--- a/src/Component/Video/Video.php
+++ b/src/Component/Video/Video.php
@@ -131,9 +131,9 @@ final class Video implements VideoInterface
     ) {
         Assertion::maxLength($title, VideoInterface::TITLE_MAX_LENGTH);
         Assertion::maxLength($description, VideoInterface::DESCRIPTION_MAX_LENGTH);
-        Assertion::false($contentLocation === null && $playerLocation === null, sprintf(
+        Assertion::false($contentLocation === null && $playerLocation === null, \sprintf(
             'At least one of parameters "%s" needs to be specified',
-            implode('", "', [
+            \implode('", "', [
                 'contentLocation',
                 'playerLocation',
             ])
@@ -375,7 +375,7 @@ final class Video implements VideoInterface
     public function withTags(array $tags)
     {
         Assertion::allIsInstanceOf($tags, TagInterface::class);
-        Assertion::lessOrEqualThan(count($tags), VideoInterface::TAG_MAX_COUNT);
+        Assertion::lessOrEqualThan(\count($tags), VideoInterface::TAG_MAX_COUNT);
 
         $instance = clone $this;
 

--- a/src/Writer/News/NewsWriter.php
+++ b/src/Writer/News/NewsWriter.php
@@ -69,34 +69,34 @@ class NewsWriter
 
     private function writeGenres(\XMLWriter $xmlWriter, array $genres)
     {
-        if (count($genres) === 0) {
+        if (\count($genres) === 0) {
             return;
         }
 
         $xmlWriter->startElement('news:genres');
-        $xmlWriter->text(implode(', ', $genres));
+        $xmlWriter->text(\implode(', ', $genres));
         $xmlWriter->endElement();
     }
 
     private function writeKeywords(\XMLWriter $xmlWriter, array $keywords)
     {
-        if (count($keywords) === 0) {
+        if (\count($keywords) === 0) {
             return;
         }
 
         $xmlWriter->startElement('news:keywords');
-        $xmlWriter->text(implode(', ', $keywords));
+        $xmlWriter->text(\implode(', ', $keywords));
         $xmlWriter->endElement();
     }
 
     private function writeStockTickers(\XMLWriter $xmlWriter, array $stockTickers)
     {
-        if (count($stockTickers) === 0) {
+        if (\count($stockTickers) === 0) {
             return;
         }
 
         $xmlWriter->startElement('news:stock_tickers');
-        $xmlWriter->text(implode(', ', $stockTickers));
+        $xmlWriter->text(\implode(', ', $stockTickers));
         $xmlWriter->endElement();
     }
 }

--- a/src/Writer/UrlWriter.php
+++ b/src/Writer/UrlWriter.php
@@ -100,7 +100,7 @@ class UrlWriter
         }
 
         $xmlWriter->startElement('priority');
-        $xmlWriter->text(number_format($priority, 1));
+        $xmlWriter->text(\number_format($priority, 1));
         $xmlWriter->endElement();
     }
 

--- a/src/Writer/Video/PlatformWriter.php
+++ b/src/Writer/Video/PlatformWriter.php
@@ -22,7 +22,7 @@ class PlatformWriter
     {
         $xmlWriter->startElement('video:platform');
         $xmlWriter->writeAttribute('relationship', $platform->relationship());
-        $xmlWriter->text(implode(' ', $platform->types()));
+        $xmlWriter->text(\implode(' ', $platform->types()));
         $xmlWriter->endElement();
     }
 }

--- a/src/Writer/Video/PriceWriter.php
+++ b/src/Writer/Video/PriceWriter.php
@@ -31,7 +31,7 @@ class PriceWriter
             $xmlWriter->writeAttribute('resolution', $price->resolution());
         }
 
-        $xmlWriter->text(number_format($price->value(), 2));
+        $xmlWriter->text(\number_format($price->value(), 2));
         $xmlWriter->endElement();
     }
 }

--- a/src/Writer/Video/RestrictionWriter.php
+++ b/src/Writer/Video/RestrictionWriter.php
@@ -22,7 +22,7 @@ class RestrictionWriter
     {
         $xmlWriter->startElement('video:restriction');
         $xmlWriter->writeAttribute('relationship', $restriction->relationship());
-        $xmlWriter->text(implode(' ', $restriction->countryCodes()));
+        $xmlWriter->text(\implode(' ', $restriction->countryCodes()));
         $xmlWriter->endElement();
     }
 }

--- a/src/Writer/Video/VideoWriter.php
+++ b/src/Writer/Video/VideoWriter.php
@@ -204,7 +204,7 @@ class VideoWriter
         }
 
         $xmlWriter->startElement('video:rating');
-        $xmlWriter->text(number_format($rating, 1));
+        $xmlWriter->text(\number_format($rating, 1));
         $xmlWriter->endElement();
     }
 

--- a/test/Unit/Component/UrlSetTest.php
+++ b/test/Unit/Component/UrlSetTest.php
@@ -40,7 +40,7 @@ final class UrlSetTest extends \PHPUnit_Framework_TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $urls = array_fill(
+        $urls = \array_fill(
             0,
             UrlSetInterface::URL_MAX_COUNT + 1,
             $this->getUrlMock()

--- a/test/Unit/Component/Video/PlayerLocationTest.php
+++ b/test/Unit/Component/Video/PlayerLocationTest.php
@@ -144,7 +144,7 @@ final class PlayerLocationTest extends \PHPUnit_Framework_TestCase
     {
         $faker = $this->getFaker();
 
-        $autoPlay = implode('=', $faker->words(2));
+        $autoPlay = \implode('=', $faker->words(2));
 
         $playerLocation = new PlayerLocation($faker->url);
 

--- a/test/Unit/Component/Video/VideoTest.php
+++ b/test/Unit/Component/Video/VideoTest.php
@@ -70,7 +70,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
 
         $faker = $this->getFaker();
 
-        $title = str_repeat('a', VideoInterface::TITLE_MAX_LENGTH + 1);
+        $title = \str_repeat('a', VideoInterface::TITLE_MAX_LENGTH + 1);
 
         new Video(
             $faker->url,
@@ -86,7 +86,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
 
         $faker = $this->getFaker();
 
-        $description = str_repeat('a', VideoInterface::DESCRIPTION_MAX_LENGTH + 1);
+        $description = \str_repeat('a', VideoInterface::DESCRIPTION_MAX_LENGTH + 1);
 
         new Video(
             $faker->url,
@@ -520,7 +520,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
 
         $faker = $this->getFaker();
 
-        $tags = array_fill(
+        $tags = \array_fill(
             0,
             VideoInterface::TAG_MAX_COUNT + 1,
             $this->getTagMock()
@@ -590,7 +590,7 @@ final class VideoTest extends \PHPUnit_Framework_TestCase
 
         $faker = $this->getFaker();
 
-        $category = str_repeat(
+        $category = \str_repeat(
             'a',
             VideoInterface::CATEGORY_MAX_LENGTH + 1
         );

--- a/test/Unit/Writer/News/NewsWriterTest.php
+++ b/test/Unit/Writer/News/NewsWriterTest.php
@@ -92,9 +92,9 @@ final class NewsWriterTest extends AbstractTestCase
         $this->expectToWriteElement($xmlWriter, 'news:publication_date', $publicationDate->format('c'));
         $this->expectToWriteElement($xmlWriter, 'news:title', $title);
         $this->expectToWriteElement($xmlWriter, 'news:access', $access);
-        $this->expectToWriteElement($xmlWriter, 'news:genres', implode(', ', $genres));
-        $this->expectToWriteElement($xmlWriter, 'news:keywords', implode(', ', $keywords));
-        $this->expectToWriteElement($xmlWriter, 'news:stock_tickers', implode(', ', $stockTickers));
+        $this->expectToWriteElement($xmlWriter, 'news:genres', \implode(', ', $genres));
+        $this->expectToWriteElement($xmlWriter, 'news:keywords', \implode(', ', $keywords));
+        $this->expectToWriteElement($xmlWriter, 'news:stock_tickers', \implode(', ', $stockTickers));
 
         $this->expectToEndElement($xmlWriter);
 

--- a/test/Unit/Writer/UrlWriterTest.php
+++ b/test/Unit/Writer/UrlWriterTest.php
@@ -97,7 +97,7 @@ final class UrlWriterTest extends AbstractTestCase
         $this->expectToWriteElement($xmlWriter, 'loc', $location);
         $this->expectToWriteElement($xmlWriter, 'lastmod', $lastModified->format('c'));
         $this->expectToWriteElement($xmlWriter, 'changefreq', $changeFrequency);
-        $this->expectToWriteElement($xmlWriter, 'priority', number_format($priority, 1));
+        $this->expectToWriteElement($xmlWriter, 'priority', \number_format($priority, 1));
 
         $this->expectToEndElement($xmlWriter);
 

--- a/test/Unit/Writer/Video/PlatformWriterTest.php
+++ b/test/Unit/Writer/Video/PlatformWriterTest.php
@@ -37,7 +37,7 @@ final class PlatformWriterTest extends AbstractTestCase
 
         $xmlWriter = $this->getXmlWriterMock();
 
-        $this->expectToWriteElement($xmlWriter, 'video:platform', implode(' ', $types), [
+        $this->expectToWriteElement($xmlWriter, 'video:platform', \implode(' ', $types), [
             'relationship' => $relationship,
         ]);
 

--- a/test/Unit/Writer/Video/PriceWriterTest.php
+++ b/test/Unit/Writer/Video/PriceWriterTest.php
@@ -32,7 +32,7 @@ final class PriceWriterTest extends AbstractTestCase
 
         $xmlWriter = $this->getXmlWriterMock();
 
-        $this->expectToWriteElement($xmlWriter, 'video:price', number_format($value, 2), [
+        $this->expectToWriteElement($xmlWriter, 'video:price', \number_format($value, 2), [
             'currency' => $currency,
         ]);
 
@@ -68,7 +68,7 @@ final class PriceWriterTest extends AbstractTestCase
 
         $xmlWriter = $this->getXmlWriterMock();
 
-        $this->expectToWriteElement($xmlWriter, 'video:price', number_format($value, 2), [
+        $this->expectToWriteElement($xmlWriter, 'video:price', \number_format($value, 2), [
             'currency' => $currency,
             'type' => $type,
             'resolution' => $resolution,

--- a/test/Unit/Writer/Video/RestrictionWriterTest.php
+++ b/test/Unit/Writer/Video/RestrictionWriterTest.php
@@ -37,7 +37,7 @@ final class RestrictionWriterTest extends AbstractTestCase
 
         $xmlWriter = $this->getXmlWriterMock();
 
-        $this->expectToWriteElement($xmlWriter, 'video:restriction', implode(' ', $countryCodes), [
+        $this->expectToWriteElement($xmlWriter, 'video:restriction', \implode(' ', $countryCodes), [
             'relationship' => $relationship,
         ]);
 

--- a/test/Unit/Writer/Video/VideoWriterTest.php
+++ b/test/Unit/Writer/Video/VideoWriterTest.php
@@ -159,7 +159,7 @@ final class VideoWriterTest extends AbstractTestCase
         $this->expectToWriteElement($xmlWriter, 'video:duration', $duration);
         $this->expectToWriteElement($xmlWriter, 'video:publication_date', $publicationDate->format('c'));
         $this->expectToWriteElement($xmlWriter, 'video:expiration_date', $expirationDate->format('c'));
-        $this->expectToWriteElement($xmlWriter, 'video:rating', number_format($rating, 1));
+        $this->expectToWriteElement($xmlWriter, 'video:rating', \number_format($rating, 1));
         $this->expectToWriteElement($xmlWriter, 'video:view_count', $viewCount);
         $this->expectToWriteElement($xmlWriter, 'video:family_friendly', $familyFriendly);
         $this->expectToWriteElement($xmlWriter, 'video:category', $category);


### PR DESCRIPTION
This PR

* [x] removes the need to look up global functions in current namespace

Follows https://github.com/refinery29/test-util/pull/126.

💁‍♂️ For reference, see 

* https://twitter.com/Ocramius/status/811504929357660160
* http://php.net/manual/en/language.namespaces.faq.php#language.namespaces.faq.shortname2
* http://veewee.github.io/blog/optimizing-php-performance-by-fq-function-calls/

>Function or constant names that do not contain a backslash like name can be resolved in 2 different ways.
>
>First, the current namespace name is prepended to _name_.
>
>Finally, if the constant or function _name_ does not exist in the current namespace, a global constant or function _name_ is used if it exists.